### PR TITLE
[receiver/awscloudwatch] Add credentials config for static keys and STS assume-role

### DIFF
--- a/.chloggen/awscloudwatchreceiver-credentials.yaml
+++ b/.chloggen/awscloudwatchreceiver-credentials.yaml
@@ -1,0 +1,23 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/awscloudwatch
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add `credentials` configuration to authenticate with static AWS credentials and/or STS role assumption instead of the default SDK credential chain.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: []
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if the change is relevant to users of libraries or exported APIs.
+# Include 'developer' if the change is relevant only for developers of this repo.
+# Default: '[user]'
+change_logs: []

--- a/receiver/awscloudwatchreceiver/README.md
+++ b/receiver/awscloudwatchreceiver/README.md
@@ -20,7 +20,7 @@ the [AWS SDK for Cloudwatch Logs](https://docs.aws.amazon.com/sdk-for-go/api/ser
 
 ## Getting Started
 
-This receiver uses the [AWS SDK](https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html) as mode of authentication, which includes [Credentials File](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html) and [IMDS](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html) authentication for EC2 instances.
+By default this receiver uses the [AWS SDK default credential chain](https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html) for authentication, which includes environment variables, the [Credentials File](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html), and [IMDS](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html) authentication for EC2 instances. Static credentials and STS role assumption can be configured instead via the `credentials` block; see [Authentication](#authentication).
 
 ## Configuration
 
@@ -34,6 +34,31 @@ This receiver uses the [AWS SDK](https://docs.aws.amazon.com/sdk-for-go/v1/devel
 | `logs`          | *optional* | `Logs`    | Configuration for logs collection. See [Logs Parameters](#logs-parameters).       |
 | `metrics`       | *optional* | `Metrics` | Configuration for metrics collection via GetMetricData. See [Metrics Parameters](#metrics-parameters-getmetricdata--listmetrics). |
 | `storage`       | *optional* | string    | The ID of a storage extension to be used for state persistence.                   |
+| `credentials`   | *optional* | `Credentials` | Explicit AWS credentials to use instead of the default SDK credential chain. See [Authentication](#authentication). |
+
+### Authentication
+
+When the `credentials` block is omitted, the default SDK credential chain is used (environment variables, shared config/credentials files, EC2/ECS instance roles, EKS IRSA, ...), optionally narrowed by `profile`.
+
+| Parameter           | Type   | Description |
+| ------------------- | ------ | ----------- |
+| `access_key_id`     | String | Static AWS access key ID. Must be set together with `secret_access_key`. Mutually exclusive with `profile`. |
+| `secret_access_key` | String | Static AWS secret access key. Must be set together with `access_key_id`. |
+| `session_token`     | String | Session token for temporary static credentials. Requires `access_key_id` and `secret_access_key`. |
+| `role_arn`          | String | ARN of an IAM role to assume via STS. |
+| `external_id`       | String | External ID passed in the AssumeRole call. Requires `role_arn`. |
+
+Static credentials and role assumption compose: when both are set, the static credentials are used as the base identity to assume the role. When only `role_arn` is set, the default credential chain provides the base identity. Example for cross-account collection:
+
+```yaml
+awscloudwatch:
+  region: us-west-2
+  credentials:
+    access_key_id: ${env:AWS_ACCESS_KEY_ID}
+    secret_access_key: ${env:AWS_SECRET_ACCESS_KEY}
+    role_arn: arn:aws:iam::123456789012:role/monitoring
+    external_id: my-external-id
+```
 
 ### Logs Parameters
 

--- a/receiver/awscloudwatchreceiver/awsconfig.go
+++ b/receiver/awscloudwatchreceiver/awsconfig.go
@@ -1,0 +1,58 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package awscloudwatchreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscloudwatchreceiver"
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+)
+
+// loadAWSConfig builds the aws.Config shared by the logs and metrics clients.
+//
+// Credential resolution:
+//   - credentials.access_key_id/secret_access_key set: static credentials.
+//   - otherwise: the default SDK chain (env vars, shared config/credentials files,
+//     EC2/ECS roles, IRSA, ...), optionally narrowed by profile.
+//   - credentials.role_arn set: that role is assumed via STS using whichever base
+//     credentials were resolved above.
+func loadAWSConfig(ctx context.Context, cfg *Config) (aws.Config, error) {
+	opts := []func(*config.LoadOptions) error{config.WithRegion(cfg.Region)}
+	if cfg.IMDSEndpoint != "" {
+		opts = append(opts, config.WithEC2IMDSEndpoint(cfg.IMDSEndpoint))
+	}
+	if cfg.Profile != "" {
+		opts = append(opts, config.WithSharedConfigProfile(cfg.Profile))
+	}
+
+	creds := cfg.Credentials.Get()
+	if creds != nil && creds.AccessKeyID != "" {
+		opts = append(opts, config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
+			creds.AccessKeyID,
+			string(creds.SecretAccessKey),
+			string(creds.SessionToken),
+		)))
+	}
+
+	awsCfg, err := config.LoadDefaultConfig(ctx, opts...)
+	if err != nil {
+		return aws.Config{}, err
+	}
+
+	if creds != nil && creds.RoleARN != "" {
+		provider := stscreds.NewAssumeRoleProvider(sts.NewFromConfig(awsCfg), creds.RoleARN,
+			func(o *stscreds.AssumeRoleOptions) {
+				if creds.ExternalID != "" {
+					o.ExternalID = aws.String(creds.ExternalID)
+				}
+			})
+		awsCfg.Credentials = aws.NewCredentialsCache(provider)
+	}
+
+	return awsCfg, nil
+}

--- a/receiver/awscloudwatchreceiver/awsconfig_test.go
+++ b/receiver/awscloudwatchreceiver/awsconfig_test.go
@@ -1,0 +1,59 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package awscloudwatchreceiver
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/config/configoptional"
+)
+
+func TestLoadAWSConfigStaticCredentials(t *testing.T) {
+	cfg := &Config{
+		Region: "us-west-2",
+		Credentials: configoptional.Some(CredentialsConfig{
+			AccessKeyID:     "AKID",
+			SecretAccessKey: "SECRET",
+			SessionToken:    "TOKEN",
+		}),
+	}
+
+	awsCfg, err := loadAWSConfig(t.Context(), cfg)
+	require.NoError(t, err)
+	require.Equal(t, "us-west-2", awsCfg.Region)
+
+	creds, err := awsCfg.Credentials.Retrieve(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, "AKID", creds.AccessKeyID)
+	require.Equal(t, "SECRET", creds.SecretAccessKey)
+	require.Equal(t, "TOKEN", creds.SessionToken)
+}
+
+func TestLoadAWSConfigAssumeRole(t *testing.T) {
+	cfg := &Config{
+		Region: "us-west-2",
+		Credentials: configoptional.Some(CredentialsConfig{
+			AccessKeyID:     "AKID",
+			SecretAccessKey: "SECRET",
+			RoleARN:         "arn:aws:iam::123456789012:role/monitoring",
+			ExternalID:      "my-external-id",
+		}),
+	}
+
+	awsCfg, err := loadAWSConfig(t.Context(), cfg)
+	require.NoError(t, err)
+	// Role assumption replaces the static provider with an STS-backed credentials cache.
+	// Retrieving from it would call STS, so only the wiring is asserted here.
+	require.IsType(t, &aws.CredentialsCache{}, awsCfg.Credentials)
+}
+
+func TestLoadAWSConfigNoCredentials(t *testing.T) {
+	cfg := &Config{Region: "eu-west-1"}
+
+	awsCfg, err := loadAWSConfig(t.Context(), cfg)
+	require.NoError(t, err)
+	require.Equal(t, "eu-west-1", awsCfg.Region)
+}

--- a/receiver/awscloudwatchreceiver/config.go
+++ b/receiver/awscloudwatchreceiver/config.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config/configopaque"
 	"go.opentelemetry.io/collector/config/configoptional"
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/scraper/scraperhelper"
@@ -27,12 +28,33 @@ var (
 
 // Config is the overall config structure for the awscloudwatchreceiver
 type Config struct {
-	Region       string        `mapstructure:"region"`
-	Profile      string        `mapstructure:"profile"`
-	IMDSEndpoint string        `mapstructure:"imds_endpoint"`
-	Logs         LogsConfig    `mapstructure:"logs"`
-	Metrics      MetricsConfig `mapstructure:"metrics"`
-	StorageID    *component.ID `mapstructure:"storage"`
+	Region       string                                     `mapstructure:"region"`
+	Profile      string                                     `mapstructure:"profile"`
+	IMDSEndpoint string                                     `mapstructure:"imds_endpoint"`
+	Logs         LogsConfig                                 `mapstructure:"logs"`
+	Metrics      MetricsConfig                              `mapstructure:"metrics"`
+	StorageID    *component.ID                              `mapstructure:"storage"`
+	Credentials  configoptional.Optional[CredentialsConfig] `mapstructure:"credentials"`
+}
+
+// CredentialsConfig configures the AWS credentials used to call the CloudWatch APIs.
+// When absent, the default SDK credential chain is used (environment variables, shared
+// config/credentials files, EC2/ECS roles, IRSA, ...).
+//
+// Static credentials (access_key_id/secret_access_key/session_token) and role assumption
+// (role_arn/external_id) compose: when both are set, the static credentials are used as the
+// base identity to assume the role. When only role_arn is set, the default chain provides
+// the base identity.
+type CredentialsConfig struct {
+	// AccessKeyID and SecretAccessKey are static AWS credentials. They must be set together.
+	AccessKeyID     string              `mapstructure:"access_key_id"`
+	SecretAccessKey configopaque.String `mapstructure:"secret_access_key"`
+	// SessionToken is the token for temporary static credentials, if used.
+	SessionToken configopaque.String `mapstructure:"session_token"`
+	// RoleARN is the ARN of an IAM role to assume via STS.
+	RoleARN string `mapstructure:"role_arn"`
+	// ExternalID is the external ID to pass in the AssumeRole call. Requires RoleARN.
+	ExternalID string `mapstructure:"external_id"`
 }
 
 // MetricsConfig is the configuration for the metrics (GetMetricData) portion of this receiver.
@@ -127,6 +149,11 @@ var (
 	errInvalidDiscoveryLimit            = errors.New("metrics discovery limit must be greater than 0")
 	errEmptyStatName                    = errors.New("stat name must not be empty")
 	errCollectionIntervalLessThanPeriod = errors.New("metrics collection_interval must be greater than or equal to period")
+	errEmptyCredentials                 = errors.New("credentials is set but empty; set static credentials and/or role_arn, or remove the block to use the default credential chain")
+	errIncompleteStaticCredentials      = errors.New("access_key_id and secret_access_key must be set together")
+	errSessionTokenWithoutKeys          = errors.New("session_token requires access_key_id and secret_access_key")
+	errExternalIDWithoutRoleARN         = errors.New("external_id requires role_arn")
+	errProfileWithStaticCredentials     = errors.New("profile and static credentials (access_key_id/secret_access_key) are mutually exclusive")
 )
 
 // Validate overrides the embedded ControllerConfig.Validate so that a zero CollectionInterval
@@ -153,9 +180,35 @@ func (c *Config) Validate() error {
 	}
 
 	var errs error
+	errs = errors.Join(errs, c.validateCredentials())
 	errs = errors.Join(errs, c.validateLogsConfig())
 	errs = errors.Join(errs, c.validateMetricsConfig())
 	return errs
+}
+
+func (c *Config) validateCredentials() error {
+	creds := c.Credentials.Get()
+	if creds == nil {
+		return nil
+	}
+	hasKeyID := creds.AccessKeyID != ""
+	hasSecret := creds.SecretAccessKey != ""
+	if !hasKeyID && !hasSecret && creds.SessionToken == "" && creds.RoleARN == "" && creds.ExternalID == "" {
+		return errEmptyCredentials
+	}
+	if hasKeyID != hasSecret {
+		return errIncompleteStaticCredentials
+	}
+	if creds.SessionToken != "" && !hasKeyID {
+		return errSessionTokenWithoutKeys
+	}
+	if creds.ExternalID != "" && creds.RoleARN == "" {
+		return errExternalIDWithoutRoleARN
+	}
+	if hasKeyID && c.Profile != "" {
+		return errProfileWithStaticCredentials
+	}
+	return nil
 }
 
 func (c *Config) validateMetricsDurations() error {

--- a/receiver/awscloudwatchreceiver/config.schema.yaml
+++ b/receiver/awscloudwatchreceiver/config.schema.yaml
@@ -18,6 +18,24 @@ $defs:
         type: string
       streams:
         $ref: stream_config
+  credentials_config:
+    description: 'CredentialsConfig configures the AWS credentials used to call the CloudWatch APIs. When absent, the default SDK credential chain is used (environment variables, shared config/credentials files, EC2/ECS roles, IRSA, ...). Static credentials (access_key_id/secret_access_key/session_token) and role assumption (role_arn/external_id) compose: when both are set, the static credentials are used as the base identity to assume the role. When only role_arn is set, the default chain provides the base identity.'
+    type: object
+    properties:
+      access_key_id:
+        description: AccessKeyID and SecretAccessKey are static AWS credentials. They must be set together.
+        type: string
+      external_id:
+        description: ExternalID is the external ID to pass in the AssumeRole call. Requires RoleARN.
+        type: string
+      role_arn:
+        description: RoleARN is the ARN of an IAM role to assume via STS.
+        type: string
+      secret_access_key:
+        $ref: go.opentelemetry.io/collector/config/configopaque.string
+      session_token:
+        description: SessionToken is the token for temporary static credentials, if used.
+        $ref: go.opentelemetry.io/collector/config/configopaque.string
   group_config:
     description: GroupConfig is the configuration for log group collection
     type: object
@@ -118,6 +136,9 @@ $defs:
 description: Config is the overall config structure for the awscloudwatchreceiver
 type: object
 properties:
+  credentials:
+    x-optional: true
+    $ref: credentials_config
   imds_endpoint:
     type: string
   logs:

--- a/receiver/awscloudwatchreceiver/config_test.go
+++ b/receiver/awscloudwatchreceiver/config_test.go
@@ -544,3 +544,153 @@ func TestValidateMetricsConfig(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateCredentials(t *testing.T) {
+	withCredentials := func(profile string, creds CredentialsConfig) Config {
+		return Config{
+			Region:  "us-west-2",
+			Profile: profile,
+			Logs: LogsConfig{
+				MaxEventsPerRequest: defaultEventLimit,
+				PollInterval:        defaultPollInterval,
+			},
+			Credentials: configoptional.Some(creds),
+		}
+	}
+
+	cases := []struct {
+		name        string
+		config      Config
+		expectedErr error
+	}{
+		{
+			name: "static keys",
+			config: withCredentials("", CredentialsConfig{
+				AccessKeyID:     "AKID",
+				SecretAccessKey: "SECRET",
+			}),
+		},
+		{
+			name: "static keys with session token",
+			config: withCredentials("", CredentialsConfig{
+				AccessKeyID:     "AKID",
+				SecretAccessKey: "SECRET",
+				SessionToken:    "TOKEN",
+			}),
+		},
+		{
+			name: "role only",
+			config: withCredentials("", CredentialsConfig{
+				RoleARN: "arn:aws:iam::123456789012:role/monitoring",
+			}),
+		},
+		{
+			name: "static keys with role and external id",
+			config: withCredentials("", CredentialsConfig{
+				AccessKeyID:     "AKID",
+				SecretAccessKey: "SECRET",
+				RoleARN:         "arn:aws:iam::123456789012:role/monitoring",
+				ExternalID:      "my-external-id",
+			}),
+		},
+		{
+			name: "profile with role",
+			config: withCredentials("my-profile", CredentialsConfig{
+				RoleARN: "arn:aws:iam::123456789012:role/monitoring",
+			}),
+		},
+		{
+			name:        "empty credentials block",
+			config:      withCredentials("", CredentialsConfig{}),
+			expectedErr: errEmptyCredentials,
+		},
+		{
+			name: "access key without secret",
+			config: withCredentials("", CredentialsConfig{
+				AccessKeyID: "AKID",
+			}),
+			expectedErr: errIncompleteStaticCredentials,
+		},
+		{
+			name: "secret without access key",
+			config: withCredentials("", CredentialsConfig{
+				SecretAccessKey: "SECRET",
+			}),
+			expectedErr: errIncompleteStaticCredentials,
+		},
+		{
+			name: "session token without static keys",
+			config: withCredentials("", CredentialsConfig{
+				SessionToken: "TOKEN",
+			}),
+			expectedErr: errSessionTokenWithoutKeys,
+		},
+		{
+			name: "external id without role",
+			config: withCredentials("", CredentialsConfig{
+				AccessKeyID:     "AKID",
+				SecretAccessKey: "SECRET",
+				ExternalID:      "my-external-id",
+			}),
+			expectedErr: errExternalIDWithoutRoleARN,
+		},
+		{
+			name: "profile with static keys",
+			config: withCredentials("my-profile", CredentialsConfig{
+				AccessKeyID:     "AKID",
+				SecretAccessKey: "SECRET",
+			}),
+			expectedErr: errProfileWithStaticCredentials,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.config.Validate()
+			if tc.expectedErr != nil {
+				require.ErrorContains(t, err, tc.expectedErr.Error())
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestLoadCredentialsConfig(t *testing.T) {
+	cm, err := confmaptest.LoadConf(filepath.Join("testdata", "config.yaml"))
+	require.NoError(t, err)
+
+	cases := []struct {
+		name     string
+		expected configoptional.Optional[CredentialsConfig]
+	}{
+		{
+			name: "credentials-static",
+			expected: configoptional.Some(CredentialsConfig{
+				AccessKeyID:     "AKIAIOSFODNN7EXAMPLE",
+				SecretAccessKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+				SessionToken:    "SESSIONTOKEN",
+			}),
+		},
+		{
+			name: "credentials-role",
+			expected: configoptional.Some(CredentialsConfig{
+				RoleARN:    "arn:aws:iam::123456789012:role/monitoring",
+				ExternalID: "my-external-id",
+			}),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			factory := NewFactory()
+			cfg := factory.CreateDefaultConfig()
+
+			loaded, err := cm.Sub(component.NewIDWithName(metadata.Type, tc.name).String())
+			require.NoError(t, err)
+			require.NoError(t, loaded.Unmarshal(cfg))
+			require.Equal(t, tc.expected, cfg.(*Config).Credentials)
+			require.NoError(t, xconfmap.Validate(cfg))
+		})
+	}
+}

--- a/receiver/awscloudwatchreceiver/go.mod
+++ b/receiver/awscloudwatchreceiver/go.mod
@@ -5,8 +5,10 @@ go 1.25.0
 require (
 	github.com/aws/aws-sdk-go-v2 v1.41.7
 	github.com/aws/aws-sdk-go-v2/config v1.32.17
+	github.com/aws/aws-sdk-go-v2/credentials v1.19.16
 	github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.57.0
 	github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.74.0
+	github.com/aws/aws-sdk-go-v2/service/sts v1.42.1
 	github.com/goccy/go-json v0.10.6
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden v0.153.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.153.0
@@ -14,6 +16,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/collector/component v1.59.0
 	go.opentelemetry.io/collector/component/componenttest v0.153.0
+	go.opentelemetry.io/collector/config/configopaque v1.59.0
 	go.opentelemetry.io/collector/config/configoptional v1.59.0
 	go.opentelemetry.io/collector/confmap v1.59.0
 	go.opentelemetry.io/collector/confmap/xconfmap v0.153.0
@@ -32,7 +35,6 @@ require (
 
 require (
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.10 // indirect
-	github.com/aws/aws-sdk-go-v2/credentials v1.19.16 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.23 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.23 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.23 // indirect
@@ -42,7 +44,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/signin v1.0.11 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.30.17 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.21 // indirect
-	github.com/aws/aws-sdk-go-v2/service/sts v1.42.1 // indirect
 	github.com/aws/smithy-go v1.25.1 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/receiver/awscloudwatchreceiver/go.sum
+++ b/receiver/awscloudwatchreceiver/go.sum
@@ -110,6 +110,8 @@ go.opentelemetry.io/collector/component v1.59.0 h1:WtulkwzsdAOM/LE0cH/IiudUgiyb2
 go.opentelemetry.io/collector/component v1.59.0/go.mod h1:5eQCM0tS6qbG2XJ6Bt67kgCxuhCbg4csVv6SywyHZ6w=
 go.opentelemetry.io/collector/component/componenttest v0.153.0 h1:u6O1l+9PUNnI22k8q4sF9wgLAUyt+y2Ov7xi1yZ+wE4=
 go.opentelemetry.io/collector/component/componenttest v0.153.0/go.mod h1:Ym/d5UxnoHmrCI5LsVANBicikNiqtwjk8uWBM+Z4jDM=
+go.opentelemetry.io/collector/config/configopaque v1.59.0 h1:32PvJXf3V4P1iUcAmN5E/mIa3+EqLx8/4mOzFU/9CjQ=
+go.opentelemetry.io/collector/config/configopaque v1.59.0/go.mod h1:75nru6ahPcZsCOnVqsSomiBKk8n+iCZgUZXlwSdT8Ik=
 go.opentelemetry.io/collector/config/configoptional v1.59.0 h1:kP751PU6KMxpw64DTPLD6vNDPjxqNJqFo7fPemu65Lc=
 go.opentelemetry.io/collector/config/configoptional v1.59.0/go.mod h1:+TnLr1EMcsR4jJGoBHOCbifgunBjV3rHWNlDWPgBJcE=
 go.opentelemetry.io/collector/confmap v1.59.0 h1:asxEEiWwNuGfmTVSctYArOTF8jcxYpS4NmPtvvFhNNI=

--- a/receiver/awscloudwatchreceiver/logs.go
+++ b/receiver/awscloudwatchreceiver/logs.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs/types"
 	"go.opentelemetry.io/collector/component"
@@ -31,9 +30,8 @@ const (
 
 type logsReceiver struct {
 	settings                      receiver.Settings
+	cfg                           *Config
 	region                        string
-	profile                       string
-	imdsEndpoint                  string
 	pollInterval                  time.Duration
 	maxEventsPerRequest           int
 	initialStartTime              time.Time
@@ -138,11 +136,10 @@ func newLogsReceiver(cfg *Config, settings receiver.Settings, consumer consumer.
 
 	return &logsReceiver{
 		settings:            settings,
+		cfg:                 cfg,
 		region:              cfg.Region,
-		profile:             cfg.Profile,
 		consumer:            consumer,
 		maxEventsPerRequest: cfg.Logs.MaxEventsPerRequest,
-		imdsEndpoint:        cfg.IMDSEndpoint,
 		autodiscover:        autodiscover,
 		pollInterval:        cfg.Logs.PollInterval,
 		initialStartTime:    startTime,
@@ -476,19 +473,10 @@ func (l *logsReceiver) ensureSession() error {
 		return nil
 	}
 
-	cfgOptions := []func(*config.LoadOptions) error{
-		config.WithRegion(l.region),
+	awsCfg, err := loadAWSConfig(context.Background(), l.cfg)
+	if err != nil {
+		return err
 	}
-
-	if l.imdsEndpoint != "" {
-		cfgOptions = append(cfgOptions, config.WithEC2IMDSEndpoint(l.imdsEndpoint))
-	}
-
-	if l.profile != "" {
-		cfgOptions = append(cfgOptions, config.WithSharedConfigProfile(l.profile))
-	}
-
-	cfg, err := config.LoadDefaultConfig(context.Background(), cfgOptions...)
-	l.client = cloudwatchlogs.NewFromConfig(cfg)
-	return err
+	l.client = cloudwatchlogs.NewFromConfig(awsCfg)
+	return nil
 }

--- a/receiver/awscloudwatchreceiver/logs_test.go
+++ b/receiver/awscloudwatchreceiver/logs_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/config/configoptional"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/receiver"
 	"go.uber.org/zap"
@@ -937,4 +938,21 @@ func (mc *mockClient) DescribeLogGroups(ctx context.Context, input *cloudwatchlo
 func (mc *mockClient) FilterLogEvents(ctx context.Context, input *cloudwatchlogs.FilterLogEventsInput, opts ...func(options *cloudwatchlogs.Options)) (*cloudwatchlogs.FilterLogEventsOutput, error) {
 	args := mc.Called(ctx, input, opts)
 	return args.Get(0).(*cloudwatchlogs.FilterLogEventsOutput), args.Error(1)
+}
+
+func TestEnsureSessionWithCredentials(t *testing.T) {
+	cfg := createDefaultConfig().(*Config)
+	cfg.Region = "us-west-2"
+	cfg.Credentials = configoptional.Some(CredentialsConfig{
+		AccessKeyID:     "AKID",
+		SecretAccessKey: "SECRET",
+	})
+
+	rcvr := newLogsReceiver(cfg, receiver.Settings{
+		TelemetrySettings: component.TelemetrySettings{
+			Logger: zap.NewNop(),
+		},
+	}, consumertest.NewNop())
+	require.NoError(t, rcvr.ensureSession())
+	require.NotNil(t, rcvr.client)
 }

--- a/receiver/awscloudwatchreceiver/metrics.go
+++ b/receiver/awscloudwatchreceiver/metrics.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatch"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
 	"go.opentelemetry.io/collector/component"
@@ -77,14 +76,7 @@ func newCloudWatchMetricsScraper(cfg *Config, settings receiver.Settings) *cloud
 
 func (s *cloudWatchMetricsScraper) start(ctx context.Context, _ component.Host) error {
 	s.settings.Logger.Debug("initializing CloudWatch client", zap.String("region", s.cfg.Region))
-	opts := []func(*config.LoadOptions) error{config.WithRegion(s.cfg.Region)}
-	if s.cfg.IMDSEndpoint != "" {
-		opts = append(opts, config.WithEC2IMDSEndpoint(s.cfg.IMDSEndpoint))
-	}
-	if s.cfg.Profile != "" {
-		opts = append(opts, config.WithSharedConfigProfile(s.cfg.Profile))
-	}
-	cfg, err := config.LoadDefaultConfig(ctx, opts...)
+	cfg, err := loadAWSConfig(ctx, s.cfg)
 	if err != nil {
 		return err
 	}

--- a/receiver/awscloudwatchreceiver/testdata/config.yaml
+++ b/receiver/awscloudwatchreceiver/testdata/config.yaml
@@ -101,3 +101,20 @@ awscloudwatch/metrics-discovery-no-namespace:
     period: 120s
     discovery:
       limit: 50
+
+awscloudwatch/credentials-static:
+  region: us-west-1
+  credentials:
+    access_key_id: AKIAIOSFODNN7EXAMPLE
+    secret_access_key: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+    session_token: SESSIONTOKEN
+  logs:
+    poll_interval: 1m
+
+awscloudwatch/credentials-role:
+  region: us-west-1
+  credentials:
+    role_arn: arn:aws:iam::123456789012:role/monitoring
+    external_id: my-external-id
+  logs:
+    poll_interval: 1m


### PR DESCRIPTION
# Description

Adds an optional credentials block to the awscloudwatch receiver to authenticate with static AWS credentials and/or STS role assumption instead of the default SDK credential chain.

- secret_access_key and session_token use configopaque.String so they are redacted in config dumps.
- Static keys and role_arn compose: when both are set, the static credentials are the base identity for the AssumeRole call; with role_arn alone, the default chain provides the base identity.
- Validation: keys must be set together; session_token requires keys; external_id requires role_arn; profile is mutually exclusive with static keys.
- Wired into the metrics scraper via a shared loadAWSConfig helper; the logs receiver will adopt the same helper in a follow-up.

# Base

This PR targets the 0.153.0 branch, which sits at the v0.153.0 upstream tag.

# Testing

Unit tests for config validation, YAML unmarshalling, and AWS config construction. `go test ./...`, `go vet`, and `make lint` pass on the receiver module.