### PR TITLE
[receiver/awscloudwatch] Report cloud.account.id and support cross-account metric collection

### DIFF
--- a/.chloggen/awscloudwatchreceiver-metrics-account-id.yaml
+++ b/.chloggen/awscloudwatchreceiver-metrics-account-id.yaml
@@ -1,0 +1,5 @@
+change_type: enhancement
+component: receiver/awscloudwatch
+note: Report the AWS account ID as the `cloud.account.id` resource attribute on collected metrics, resolved via STS `GetCallerIdentity`.
+issues: []
+change_logs: []

--- a/.chloggen/awscloudwatchreceiver-metrics-cross-account.yaml
+++ b/.chloggen/awscloudwatchreceiver-metrics-cross-account.yaml
@@ -1,0 +1,5 @@
+change_type: enhancement
+component: receiver/awscloudwatch
+note: Support cross-account metric collection. Discovery gains `include_linked_accounts` and `account_identifiers`, explicit queries gain `account_id`, and metrics are grouped into resources by their owning `cloud.account.id`.
+issues: []
+change_logs: []

--- a/receiver/awscloudwatchreceiver/README.md
+++ b/receiver/awscloudwatchreceiver/README.md
@@ -88,7 +88,7 @@ List every metric you want to collect. Each entry supports:
 | `metric_name` | String          | yes      | CloudWatch metric name, e.g. `CPUUtilization`. |
 | `dimensions`  | Map             | no       | CloudWatch dimension key/value pairs. Required for metrics that are scoped to a specific resource (e.g. a single EC2 instance or DynamoDB table). Original casing is preserved. |
 | `stats`       | List of strings | no       | Which CloudWatch statistics to fetch. See [Statistics](#statistics) below. |
-| `account_id`  | String          | no       | Source account the metric is located in, for cross-account monitoring. When set, the metric is fetched from that account via `GetMetricData` and reported under its `cloud.account.id`. Requires the receiver to run in a monitoring account. See [Cross-account monitoring](#cross-account-monitoring). |
+| `account_id`  | String          | no       | Source account the metric is located in, for cross-account monitoring. When set, the metric is fetched from that account via `GetMetricData` and reported under its `cloud.account.id`. The receiver must run in a monitoring account with that source account linked; otherwise `GetMetricData` returns a `Forbidden` status and the metric is dropped (a warning is logged). See [Cross-account monitoring](#cross-account-monitoring). |
 
 #### Auto-discovery (`discovery`)
 
@@ -111,7 +111,9 @@ In a [CloudWatch cross-account observability](https://docs.aws.amazon.com/Amazon
 - **Auto-discovery:** set `discovery.include_linked_accounts: true` to discover metrics across all linked accounts, or add `discovery.account_identifiers: [<id>, ...]` to restrict to specific source accounts. Because `ListMetrics` filters one owning account at a time, each identifier is queried separately, so the `limit` applies per account.
 - **Explicit queries:** set `account_id` on a query to fetch that metric from a specific source account.
 
-Each metric is emitted under its owning account's `cloud.account.id` resource attribute. Without any cross-account configuration, the receiver collects only from its own account (the default).
+Each metric is emitted under its source account's `cloud.account.id` resource attribute. Without any cross-account configuration, the receiver collects only from its own account (the default).
+
+> **Prerequisite:** cross-account collection requires the credentials to belong to a CloudWatch **monitoring account** with the source accounts linked to it (via [Observability Access Manager](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Unified-Cross-Account-Setup.html)). The receiver cannot detect this from configuration alone. If a source account is not reachable, `GetMetricData` returns a `Forbidden` status for those metrics rather than an error, so they are simply absent from the output; the receiver logs a warning (`GetMetricData returned a non-complete status for a metric`) identifying the account so the misconfiguration is diagnosable.
 
 #### Statistics
 

--- a/receiver/awscloudwatchreceiver/README.md
+++ b/receiver/awscloudwatchreceiver/README.md
@@ -88,7 +88,7 @@ List every metric you want to collect. Each entry supports:
 | `metric_name` | String          | yes      | CloudWatch metric name, e.g. `CPUUtilization`. |
 | `dimensions`  | Map             | no       | CloudWatch dimension key/value pairs. Required for metrics that are scoped to a specific resource (e.g. a single EC2 instance or DynamoDB table). Original casing is preserved. |
 | `stats`       | List of strings | no       | Which CloudWatch statistics to fetch. See [Statistics](#statistics) below. |
-| `account_id`  | String          | no       | Source account the metric is located in, for cross-account monitoring. When set, the metric is fetched from that account via `GetMetricData` and reported under its `cloud.account.id`. The receiver must run in a monitoring account with that source account linked; otherwise `GetMetricData` returns a `Forbidden` status and the metric is dropped (a warning is logged). See [Cross-account monitoring](#cross-account-monitoring). |
+| `account_id`  | String          | no       | Source account (a 12-digit account ID) the metric is located in, for cross-account monitoring. When set, the metric is fetched from that account via `GetMetricData` and reported under its `cloud.account.id`. The receiver must run in a monitoring account with that source account linked; otherwise `GetMetricData` returns a `Forbidden` status and the metric is dropped (a warning is logged). See [Cross-account monitoring](#cross-account-monitoring). |
 
 #### Auto-discovery (`discovery`)
 
@@ -102,7 +102,7 @@ Instead of listing metrics manually, the receiver can call [ListMetrics](https:/
 | `limit`                | Integer         | 100     | Maximum number of metrics to discover and scrape, applied **per account** (in a cross-account setup, each source account may contribute up to `limit` metrics). |
 | `stats`                | List of strings | —       | Statistics to fetch for every discovered metric. Same values as in `queries`. |
 | `include_linked_accounts` | Boolean      | false   | When running in a monitoring account, discover metrics from linked source accounts. See [Cross-account monitoring](#cross-account-monitoring). |
-| `account_identifiers`  | List of strings | —       | Restrict cross-account discovery to specific source account IDs. Requires `include_linked_accounts: true`. When omitted (with `include_linked_accounts: true`), metrics from all linked accounts are discovered. |
+| `account_identifiers`  | List of strings | —       | Restrict cross-account discovery to specific source account IDs (each a 12-digit account ID). Requires `include_linked_accounts: true`. When omitted (with `include_linked_accounts: true`), metrics from all linked accounts are discovered. |
 
 #### Cross-account monitoring
 

--- a/receiver/awscloudwatchreceiver/README.md
+++ b/receiver/awscloudwatchreceiver/README.md
@@ -116,7 +116,7 @@ Extended statistics (percentiles, trimmed means, etc.): `p99`, `p95`, `p50`, `tm
 All metrics follow the [CloudWatch Metric Streams OpenTelemetry 1.0.0 format](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-metric-streams-formats-opentelemetry-100.html):
 
 - **Metric name:** `amazonaws.com/{Namespace}/{MetricName}` (CloudWatch casing preserved)
-- **Resource attributes:** `cloud.provider = aws`, `cloud.region = <configured region>`
+- **Resource attributes:** `cloud.provider = aws`, `cloud.region = <configured region>`, and `cloud.account.id` (resolved via STS `GetCallerIdentity`; omitted when it cannot be resolved)
 - **Data point attributes:** `Namespace`, `MetricName`, and `Dimensions` (a nested key/value map, omitted when no dimensions are set)
 
 #### Examples

--- a/receiver/awscloudwatchreceiver/README.md
+++ b/receiver/awscloudwatchreceiver/README.md
@@ -88,6 +88,7 @@ List every metric you want to collect. Each entry supports:
 | `metric_name` | String          | yes      | CloudWatch metric name, e.g. `CPUUtilization`. |
 | `dimensions`  | Map             | no       | CloudWatch dimension key/value pairs. Required for metrics that are scoped to a specific resource (e.g. a single EC2 instance or DynamoDB table). Original casing is preserved. |
 | `stats`       | List of strings | no       | Which CloudWatch statistics to fetch. See [Statistics](#statistics) below. |
+| `account_id`  | String          | no       | Source account that owns this metric, for cross-account monitoring. When set, the metric is fetched from that account via `GetMetricData` and reported under its `cloud.account.id`. Requires the receiver to run in a monitoring account. See [Cross-account monitoring](#cross-account-monitoring). |
 
 #### Auto-discovery (`discovery`)
 
@@ -98,8 +99,19 @@ Instead of listing metrics manually, the receiver can call [ListMetrics](https:/
 | `filters`              | Object          | —       | Optional sub-block to narrow which metrics are discovered. If omitted, all metrics in all namespaces are discovered. |
 | `filters.namespace`    | String          | —       | Restrict discovery to a single namespace (e.g. `AWS/EC2`). |
 | `filters.metric_name`  | String          | —       | Restrict discovery to metrics with this name. |
-| `limit`                | Integer         | 100     | Maximum number of metrics to discover and scrape per collection cycle. |
+| `limit`                | Integer         | 100     | Maximum number of metrics to discover and scrape, applied **per account** (in a cross-account setup, each source account may contribute up to `limit` metrics). |
 | `stats`                | List of strings | —       | Statistics to fetch for every discovered metric. Same values as in `queries`. |
+| `include_linked_accounts` | Boolean      | false   | When running in a monitoring account, discover metrics from linked source accounts. See [Cross-account monitoring](#cross-account-monitoring). |
+| `account_identifiers`  | List of strings | —       | Restrict cross-account discovery to specific source account IDs. Requires `include_linked_accounts: true`. When omitted (with `include_linked_accounts: true`), metrics from all linked accounts are discovered. |
+
+#### Cross-account monitoring
+
+In a [CloudWatch cross-account observability](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Unified-Cross-Account.html) setup, a *monitoring account* can collect metrics from linked *source accounts*. Run the receiver with credentials for the monitoring account and:
+
+- **Auto-discovery:** set `discovery.include_linked_accounts: true` to discover metrics across all linked accounts, or add `discovery.account_identifiers: [<id>, ...]` to restrict to specific source accounts. Because `ListMetrics` filters one owning account at a time, each identifier is queried separately, so the `limit` applies per account.
+- **Explicit queries:** set `account_id` on a query to fetch that metric from a specific source account.
+
+Each metric is emitted under its owning account's `cloud.account.id` resource attribute. Without any cross-account configuration, the receiver collects only from its own account (the default).
 
 #### Statistics
 
@@ -176,6 +188,25 @@ awscloudwatch:
       filters:
         namespace: AWS/EC2
       limit: 200
+```
+
+Discover EC2 metrics across specific linked source accounts (run from a monitoring account):
+
+```yaml
+awscloudwatch:
+  region: us-east-1
+  metrics:
+    collection_interval: 5m
+    period: 300s
+    delay: 10m
+    discovery:
+      filters:
+        namespace: AWS/EC2
+      limit: 100
+      include_linked_accounts: true
+      account_identifiers:
+        - "111111111111"
+        - "222222222222"
 ```
 
 #### Logs Autodiscovery Example Configuration

--- a/receiver/awscloudwatchreceiver/README.md
+++ b/receiver/awscloudwatchreceiver/README.md
@@ -88,7 +88,7 @@ List every metric you want to collect. Each entry supports:
 | `metric_name` | String          | yes      | CloudWatch metric name, e.g. `CPUUtilization`. |
 | `dimensions`  | Map             | no       | CloudWatch dimension key/value pairs. Required for metrics that are scoped to a specific resource (e.g. a single EC2 instance or DynamoDB table). Original casing is preserved. |
 | `stats`       | List of strings | no       | Which CloudWatch statistics to fetch. See [Statistics](#statistics) below. |
-| `account_id`  | String          | no       | Source account that owns this metric, for cross-account monitoring. When set, the metric is fetched from that account via `GetMetricData` and reported under its `cloud.account.id`. Requires the receiver to run in a monitoring account. See [Cross-account monitoring](#cross-account-monitoring). |
+| `account_id`  | String          | no       | Source account the metric is located in, for cross-account monitoring. When set, the metric is fetched from that account via `GetMetricData` and reported under its `cloud.account.id`. Requires the receiver to run in a monitoring account. See [Cross-account monitoring](#cross-account-monitoring). |
 
 #### Auto-discovery (`discovery`)
 

--- a/receiver/awscloudwatchreceiver/config.go
+++ b/receiver/awscloudwatchreceiver/config.go
@@ -17,7 +17,7 @@ import (
 )
 
 // accountIDPattern matches an AWS account ID: exactly 12 digits.
-var accountIDPattern = regexp.MustCompile(`^[0-9]{12}$`)
+var accountIDPattern = regexp.MustCompile(`^\d{12}$`)
 
 var (
 	defaultPollInterval         = time.Minute

--- a/receiver/awscloudwatchreceiver/config.go
+++ b/receiver/awscloudwatchreceiver/config.go
@@ -84,6 +84,11 @@ type MetricQuery struct {
 	MetricName string            `mapstructure:"metric_name"`
 	Dimensions map[string]string `mapstructure:"dimensions"`
 	Stats      []string          `mapstructure:"stats"`
+	// AccountID optionally identifies the AWS account that owns this metric. In a
+	// cross-account monitoring setup it selects the source account to query via
+	// GetMetricData and is reported as the cloud.account.id resource attribute. When
+	// empty, the receiver's own resolved account ID is used.
+	AccountID string `mapstructure:"account_id"`
 }
 
 // LogsConfig is the configuration for the logs portion of this receiver

--- a/receiver/awscloudwatchreceiver/config.go
+++ b/receiver/awscloudwatchreceiver/config.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"regexp"
 	"time"
 
 	"go.opentelemetry.io/collector/component"
@@ -14,6 +15,9 @@ import (
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/scraper/scraperhelper"
 )
+
+// accountIDPattern matches an AWS account ID: exactly 12 digits.
+var accountIDPattern = regexp.MustCompile(`^[0-9]{12}$`)
 
 var (
 	defaultPollInterval         = time.Minute
@@ -145,6 +149,7 @@ var (
 	errMetricsAndDiscoveryConfigured    = errors.New("metrics and discovery are mutually exclusive; set one or the other")
 	errInvalidDiscoveryLimit            = errors.New("metrics discovery limit must be greater than 0")
 	errAccountIdentifiersWithoutLinked  = errors.New("metrics.discovery.account_identifiers requires include_linked_accounts to be true")
+	errInvalidAccountID                 = errors.New("account id must be a 12-digit number")
 	errEmptyStatName                    = errors.New("stat name must not be empty")
 	errCollectionIntervalLessThanPeriod = errors.New("metrics collection_interval must be greater than or equal to period")
 )
@@ -207,6 +212,11 @@ func (c *Config) validateMetricsConfig() error {
 			(discovery.IncludeLinkedAccounts == nil || !*discovery.IncludeLinkedAccounts) {
 			return errAccountIdentifiersWithoutLinked
 		}
+		for j, id := range discovery.AccountIdentifiers {
+			if !accountIDPattern.MatchString(id) {
+				return fmt.Errorf("metrics.discovery.account_identifiers[%d] %q: %w", j, id, errInvalidAccountID)
+			}
+		}
 		for j, st := range discovery.Stats {
 			if st == "" {
 				return fmt.Errorf("metrics.discovery.stats[%d]: %w", j, errEmptyStatName)
@@ -226,6 +236,9 @@ func (c *Config) validateMetricsConfig() error {
 		}
 		if m.MetricName == "" {
 			return fmt.Errorf("metrics[%d]: %w", i, errMetricMissingName)
+		}
+		if m.AccountID != "" && !accountIDPattern.MatchString(m.AccountID) {
+			return fmt.Errorf("metrics[%d].account_id %q: %w", i, m.AccountID, errInvalidAccountID)
 		}
 		for j, st := range m.Stats {
 			if st == "" {

--- a/receiver/awscloudwatchreceiver/config.go
+++ b/receiver/awscloudwatchreceiver/config.go
@@ -93,10 +93,10 @@ type MetricQuery struct {
 	MetricName string            `mapstructure:"metric_name"`
 	Dimensions map[string]string `mapstructure:"dimensions"`
 	Stats      []string          `mapstructure:"stats"`
-	// AccountID optionally identifies the AWS account that owns this metric. In a
-	// cross-account monitoring setup it selects the source account to query via
-	// GetMetricData and is reported as the cloud.account.id resource attribute. When
-	// empty, the receiver's own resolved account ID is used.
+	// AccountID optionally identifies the AWS account the metric is located in (its
+	// source account). In a cross-account monitoring setup it selects which account to
+	// retrieve the metric from via GetMetricData and is reported as the cloud.account.id
+	// resource attribute. When empty, the receiver's own resolved account ID is used.
 	AccountID string `mapstructure:"account_id"`
 }
 

--- a/receiver/awscloudwatchreceiver/config.go
+++ b/receiver/awscloudwatchreceiver/config.go
@@ -59,10 +59,19 @@ type MetricsConfig struct {
 // Discovered metrics are then scraped with GetMetricData. Mutually exclusive with metrics (explicit list).
 type MetricsDiscoveryConfig struct {
 	Filters configoptional.Optional[MetricsDiscoveryFilters] `mapstructure:"filters"`
-	Limit   int                                              `mapstructure:"limit"` // max metrics to discover and scrape (default 100)
+	// Limit is the maximum number of metrics to discover and scrape per account (default 100).
+	// In a cross-account setup it applies independently to each source account.
+	Limit int `mapstructure:"limit"`
 	// Stats selects which CloudWatch statistics to fetch for all discovered metrics.
 	// Same semantics as MetricQuery.Stats.
 	Stats []string `mapstructure:"stats"`
+	// IncludeLinkedAccounts, when true and run from a monitoring account, discovers
+	// metrics from linked source accounts in addition to (or filtered by) AccountIdentifiers.
+	IncludeLinkedAccounts *bool `mapstructure:"include_linked_accounts"`
+	// AccountIdentifiers optionally narrows cross-account discovery to specific source
+	// accounts. ListMetrics filters one owning account at a time, so each identifier is
+	// queried separately. Requires IncludeLinkedAccounts to be true.
+	AccountIdentifiers []string `mapstructure:"account_identifiers"`
 }
 
 // MetricsDiscoveryFilters optionally narrows which metrics are discovered.
@@ -135,6 +144,7 @@ var (
 	errMetricMissingName                = errors.New("metric must have metric_name")
 	errMetricsAndDiscoveryConfigured    = errors.New("metrics and discovery are mutually exclusive; set one or the other")
 	errInvalidDiscoveryLimit            = errors.New("metrics discovery limit must be greater than 0")
+	errAccountIdentifiersWithoutLinked  = errors.New("metrics.discovery.account_identifiers requires include_linked_accounts to be true")
 	errEmptyStatName                    = errors.New("stat name must not be empty")
 	errCollectionIntervalLessThanPeriod = errors.New("metrics collection_interval must be greater than or equal to period")
 )
@@ -192,6 +202,10 @@ func (c *Config) validateMetricsConfig() error {
 	if discovery := c.Metrics.Discovery; discovery != nil {
 		if discovery.Limit <= 0 {
 			return errInvalidDiscoveryLimit
+		}
+		if len(discovery.AccountIdentifiers) > 0 &&
+			(discovery.IncludeLinkedAccounts == nil || !*discovery.IncludeLinkedAccounts) {
+			return errAccountIdentifiersWithoutLinked
 		}
 		for j, st := range discovery.Stats {
 			if st == "" {

--- a/receiver/awscloudwatchreceiver/config.schema.yaml
+++ b/receiver/awscloudwatchreceiver/config.schema.yaml
@@ -46,6 +46,9 @@ $defs:
     description: 'MetricQuery defines a single CloudWatch metric to scrape via GetMetricData. When Stats is empty all four statistics (Sum, SampleCount, Minimum, Maximum) are fetched and combined into an OpenTelemetry Summary metric aligned with the CloudWatch Metric Streams OpenTelemetry 1.0.0 format. When Stats is set, each named statistic is fetched and emitted as a separate Gauge data point on the same metric, with a "stat" attribute identifying the statistic. CloudWatch statistic names: Sum, Average, Minimum, Maximum, SampleCount, p99, p95, etc.'
     type: object
     properties:
+      account_id:
+        description: AccountID optionally identifies the AWS account the metric is located in (its source account). In a cross-account monitoring setup it selects which account to retrieve the metric from via GetMetricData and is reported as the cloud.account.id resource attribute. When empty, the receiver's own resolved account ID is used.
+        type: string
       dimensions:
         type: object
         additionalProperties:
@@ -58,9 +61,6 @@ $defs:
         type: array
         items:
           type: string
-      account_id:
-        description: AccountID optionally identifies the AWS account the metric is located in (its source account). In a cross-account monitoring setup it selects which account to retrieve the metric from via GetMetricData and is reported as the cloud.account.id resource attribute. When empty, the receiver's own resolved account ID is used.
-        type: string
   metrics_config:
     description: MetricsConfig is the configuration for the metrics (GetMetricData) portion of this receiver. Either Metrics (explicit list) or Discovery (ListMetrics-based) may be set, not both. Collection interval and scraper behavior are controlled via the embedded ControllerConfig.
     type: object
@@ -86,23 +86,23 @@ $defs:
     description: MetricsDiscoveryConfig configures automatic discovery of metrics via ListMetrics. Discovered metrics are then scraped with GetMetricData. Mutually exclusive with metrics (explicit list).
     type: object
     properties:
+      account_identifiers:
+        description: AccountIdentifiers optionally narrows cross-account discovery to specific source accounts. ListMetrics filters one owning account at a time, so each identifier is queried separately. Requires IncludeLinkedAccounts to be true.
+        type: array
+        items:
+          type: string
       filters:
         x-optional: true
         $ref: metrics_discovery_filters
+      include_linked_accounts:
+        description: IncludeLinkedAccounts, when true and run from a monitoring account, discovers metrics from linked source accounts in addition to (or filtered by) AccountIdentifiers.
+        x-pointer: true
+        type: boolean
       limit:
         description: Limit is the maximum number of metrics to discover and scrape per account (default 100). In a cross-account setup it applies independently to each source account.
         type: integer
       stats:
         description: Stats selects which CloudWatch statistics to fetch for all discovered metrics. Same semantics as MetricQuery.Stats.
-        type: array
-        items:
-          type: string
-      include_linked_accounts:
-        description: IncludeLinkedAccounts, when true and run from a monitoring account, discovers metrics from linked source accounts in addition to (or filtered by) AccountIdentifiers.
-        x-pointer: true
-        type: boolean
-      account_identifiers:
-        description: AccountIdentifiers optionally narrows cross-account discovery to specific source accounts. ListMetrics filters one owning account at a time, so each identifier is queried separately. Requires IncludeLinkedAccounts to be true.
         type: array
         items:
           type: string

--- a/receiver/awscloudwatchreceiver/config.schema.yaml
+++ b/receiver/awscloudwatchreceiver/config.schema.yaml
@@ -58,6 +58,9 @@ $defs:
         type: array
         items:
           type: string
+      account_id:
+        description: AccountID optionally identifies the AWS account that owns this metric. In a cross-account monitoring setup it selects the source account to query via GetMetricData and is reported as the cloud.account.id resource attribute. When empty, the receiver's own resolved account ID is used.
+        type: string
   metrics_config:
     description: MetricsConfig is the configuration for the metrics (GetMetricData) portion of this receiver. Either Metrics (explicit list) or Discovery (ListMetrics-based) may be set, not both. Collection interval and scraper behavior are controlled via the embedded ControllerConfig.
     type: object
@@ -87,9 +90,19 @@ $defs:
         x-optional: true
         $ref: metrics_discovery_filters
       limit:
+        description: Limit is the maximum number of metrics to discover and scrape per account (default 100). In a cross-account setup it applies independently to each source account.
         type: integer
       stats:
         description: Stats selects which CloudWatch statistics to fetch for all discovered metrics. Same semantics as MetricQuery.Stats.
+        type: array
+        items:
+          type: string
+      include_linked_accounts:
+        description: IncludeLinkedAccounts, when true and run from a monitoring account, discovers metrics from linked source accounts in addition to (or filtered by) AccountIdentifiers.
+        x-pointer: true
+        type: boolean
+      account_identifiers:
+        description: AccountIdentifiers optionally narrows cross-account discovery to specific source accounts. ListMetrics filters one owning account at a time, so each identifier is queried separately. Requires IncludeLinkedAccounts to be true.
         type: array
         items:
           type: string

--- a/receiver/awscloudwatchreceiver/config.schema.yaml
+++ b/receiver/awscloudwatchreceiver/config.schema.yaml
@@ -59,7 +59,7 @@ $defs:
         items:
           type: string
       account_id:
-        description: AccountID optionally identifies the AWS account that owns this metric. In a cross-account monitoring setup it selects the source account to query via GetMetricData and is reported as the cloud.account.id resource attribute. When empty, the receiver's own resolved account ID is used.
+        description: AccountID optionally identifies the AWS account the metric is located in (its source account). In a cross-account monitoring setup it selects which account to retrieve the metric from via GetMetricData and is reported as the cloud.account.id resource attribute. When empty, the receiver's own resolved account ID is used.
         type: string
   metrics_config:
     description: MetricsConfig is the configuration for the metrics (GetMetricData) portion of this receiver. Either Metrics (explicit list) or Discovery (ListMetrics-based) may be set, not both. Collection interval and scraper behavior are controlled via the embedded ControllerConfig.

--- a/receiver/awscloudwatchreceiver/config_test.go
+++ b/receiver/awscloudwatchreceiver/config_test.go
@@ -463,6 +463,28 @@ func TestValidateMetricsConfig(t *testing.T) {
 			expectedErr: errInvalidDiscoveryLimit,
 		},
 		{
+			name: "account identifiers without linked accounts",
+			config: withMetrics(MetricsConfig{
+				Period: 300 * time.Second,
+				Discovery: &MetricsDiscoveryConfig{
+					Limit:              100,
+					AccountIdentifiers: []string{"111111111111"},
+				},
+			}),
+			expectedErr: errAccountIdentifiersWithoutLinked,
+		},
+		{
+			name: "account identifiers with linked accounts valid",
+			config: withMetrics(MetricsConfig{
+				Period: 300 * time.Second,
+				Discovery: &MetricsDiscoveryConfig{
+					Limit:                 100,
+					IncludeLinkedAccounts: aws.Bool(true),
+					AccountIdentifiers:    []string{"111111111111"},
+				},
+			}),
+		},
+		{
 			name: "collection interval too short",
 			config: withMetrics(MetricsConfig{
 				ControllerConfig: scraperhelper.ControllerConfig{CollectionInterval: 500 * time.Millisecond},

--- a/receiver/awscloudwatchreceiver/config_test.go
+++ b/receiver/awscloudwatchreceiver/config_test.go
@@ -485,6 +485,37 @@ func TestValidateMetricsConfig(t *testing.T) {
 			}),
 		},
 		{
+			name: "malformed account identifier",
+			config: withMetrics(MetricsConfig{
+				Period: 300 * time.Second,
+				Discovery: &MetricsDiscoveryConfig{
+					Limit:                 100,
+					IncludeLinkedAccounts: aws.Bool(true),
+					AccountIdentifiers:    []string{"11111111111"}, // 11 digits
+				},
+			}),
+			expectedErr: errInvalidAccountID,
+		},
+		{
+			name: "malformed query account_id",
+			config: withMetrics(MetricsConfig{
+				Period: 300 * time.Second,
+				Queries: []MetricQuery{
+					{Namespace: "AWS/EC2", MetricName: "CPUUtilization", AccountID: "not-an-account"},
+				},
+			}),
+			expectedErr: errInvalidAccountID,
+		},
+		{
+			name: "valid query account_id",
+			config: withMetrics(MetricsConfig{
+				Period: 300 * time.Second,
+				Queries: []MetricQuery{
+					{Namespace: "AWS/EC2", MetricName: "CPUUtilization", AccountID: "222222222222"},
+				},
+			}),
+		},
+		{
 			name: "collection interval too short",
 			config: withMetrics(MetricsConfig{
 				ControllerConfig: scraperhelper.ControllerConfig{CollectionInterval: 500 * time.Millisecond},

--- a/receiver/awscloudwatchreceiver/credentialsprovider_test.go
+++ b/receiver/awscloudwatchreceiver/credentialsprovider_test.go
@@ -91,6 +91,7 @@ func TestMetricsScraperUsesCredentialsProvider(t *testing.T) {
 	})
 	require.NoError(t, scraper.start(t.Context(), host))
 	require.NotNil(t, scraper.client)
+	require.NotNil(t, scraper.stsClient)
 }
 
 func TestLogsReceiverUsesCredentialsProvider(t *testing.T) {

--- a/receiver/awscloudwatchreceiver/go.mod
+++ b/receiver/awscloudwatchreceiver/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.16
 	github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.57.0
 	github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.74.0
+	github.com/aws/aws-sdk-go-v2/service/sts v1.42.1
 	github.com/goccy/go-json v0.10.6
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden v0.153.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.153.0
@@ -42,7 +43,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/signin v1.0.11 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.30.17 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.21 // indirect
-	github.com/aws/aws-sdk-go-v2/service/sts v1.42.1 // indirect
 	github.com/aws/smithy-go v1.25.1 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/receiver/awscloudwatchreceiver/metrics.go
+++ b/receiver/awscloudwatchreceiver/metrics.go
@@ -373,9 +373,21 @@ func (s *cloudWatchMetricsScraper) pollBatch(ctx context.Context, batch []Metric
 	}
 
 	withData := 0
+	warned := make(map[int]bool)
 	for _, r := range allResults {
 		if len(r.Values) > 0 {
 			withData++
+		}
+		// Surface non-complete statuses that would otherwise be dropped as empty data.
+		// Forbidden in particular signals the metric's account is not accessible (the
+		// receiver is not a monitoring account, or the source account is not linked),
+		// which is the common cross-account misconfiguration. Deduplicate per metric so
+		// a metric's sub-queries do not each emit an identical warning.
+		if r.StatusCode == types.StatusCodeForbidden || r.StatusCode == types.StatusCodeInternalError {
+			if mi, _, err := parseQueryID(aws.ToString(r.Id)); err == nil && mi >= 0 && mi < len(batch) && !warned[mi] {
+				warned[mi] = true
+				s.logResultStatus(batch[mi], r)
+			}
 		}
 	}
 	s.settings.Logger.Debug("GetMetricData response",
@@ -395,6 +407,25 @@ func (s *cloudWatchMetricsScraper) pollBatch(ctx context.Context, batch []Metric
 		}
 	}
 	return md, nil
+}
+
+// logResultStatus emits a warning describing a non-complete GetMetricData result so that
+// silently-dropped metrics (e.g. a Forbidden cross-account query) are diagnosable.
+func (s *cloudWatchMetricsScraper) logResultStatus(q MetricQuery, r types.MetricDataResult) {
+	fields := []zap.Field{
+		zap.String("status", string(r.StatusCode)),
+		zap.String("namespace", q.Namespace),
+		zap.String("metric_name", q.MetricName),
+		zap.String("account_id", s.effectiveAccountID(q)),
+	}
+	for _, m := range r.Messages {
+		if m.Value != nil {
+			fields = append(fields, zap.String("message", aws.ToString(m.Value)))
+		}
+	}
+	s.settings.Logger.Warn("GetMetricData returned a non-complete status for a metric; "+
+		"a Forbidden status usually means the receiver is not running in a monitoring account "+
+		"or the source account is not linked", fields...)
 }
 
 func dimensionsFromMap(d map[string]string) []types.Dimension {

--- a/receiver/awscloudwatchreceiver/metrics.go
+++ b/receiver/awscloudwatchreceiver/metrics.go
@@ -358,14 +358,23 @@ func dimensionsFromMap(d map[string]string) []types.Dimension {
 // setResourceAttributes sets the resource-level attributes that identify the AWS source.
 // Aligned with the CloudWatch Metric Streams OpenTelemetry 1.0.0 format: cloud.provider,
 // cloud.account.id, and cloud.region are set on the resource; namespace and dimensions go
-// on data points. cloud.account.id is omitted when the account ID could not be resolved.
-func (s *cloudWatchMetricsScraper) setResourceAttributes(resource pcommon.Resource) {
+// on data points. cloud.account.id is omitted when accountID is empty.
+func (s *cloudWatchMetricsScraper) setResourceAttributes(resource pcommon.Resource, accountID string) {
 	attrs := resource.Attributes()
 	attrs.PutStr(string(conventions.CloudProviderKey), conventions.CloudProviderAWS.Value.AsString())
-	if s.accountID != "" {
-		attrs.PutStr(string(conventions.CloudAccountIDKey), s.accountID)
+	if accountID != "" {
+		attrs.PutStr(string(conventions.CloudAccountIDKey), accountID)
 	}
 	attrs.PutStr(string(conventions.CloudRegionKey), s.cfg.Region)
+}
+
+// effectiveAccountID returns the account ID to attribute to a metric query: the query's
+// own AccountID when set (cross-account), otherwise the receiver's resolved account ID.
+func (s *cloudWatchMetricsScraper) effectiveAccountID(q MetricQuery) string {
+	if q.AccountID != "" {
+		return q.AccountID
+	}
+	return s.accountID
 }
 
 // parseQueryID parses a sub-query ID of the form "q{metricIdx}_{statIdx}".
@@ -424,10 +433,22 @@ func (s *cloudWatchMetricsScraper) convertGetMetricDataToPdata(results []types.M
 	}
 
 	md := pmetric.NewMetrics()
-	rm := md.ResourceMetrics().AppendEmpty()
-	s.setResourceAttributes(rm.Resource())
-	sm := rm.ScopeMetrics().AppendEmpty()
-	sm.Scope().SetName(metadata.ScopeName)
+
+	// Group metrics into one ResourceMetrics per account ID so that cross-account
+	// metrics carry the correct cloud.account.id. In the single-account case all
+	// metrics share the receiver's resolved account ID and land in one resource.
+	scopeByAccount := make(map[string]pmetric.ScopeMetrics)
+	scopeForAccount := func(accountID string) pmetric.ScopeMetrics {
+		if sm, ok := scopeByAccount[accountID]; ok {
+			return sm
+		}
+		rm := md.ResourceMetrics().AppendEmpty()
+		s.setResourceAttributes(rm.Resource(), accountID)
+		sm := rm.ScopeMetrics().AppendEmpty()
+		sm.Scope().SetName(metadata.ScopeName)
+		scopeByAccount[accountID] = sm
+		return sm
+	}
 
 	periodNano := pcommon.Timestamp(s.period.Nanoseconds())
 
@@ -444,7 +465,7 @@ func (s *cloudWatchMetricsScraper) convertGetMetricDataToPdata(results []types.M
 			continue
 		}
 
-		metric := sm.Metrics().AppendEmpty()
+		metric := scopeForAccount(s.effectiveAccountID(q)).Metrics().AppendEmpty()
 		metric.SetName("amazonaws.com/" + q.Namespace + "/" + q.MetricName)
 
 		if len(q.Stats) == 0 {
@@ -511,10 +532,8 @@ func (s *cloudWatchMetricsScraper) convertGetMetricDataToPdata(results []types.M
 		}
 	}
 
-	// Drop the ResourceMetrics if no metric had any data.
-	if sm.Metrics().Len() == 0 {
-		return pmetric.NewMetrics()
-	}
+	// No ResourceMetrics are created unless a metric had data, so an empty result
+	// means nothing was emitted.
 	return md
 }
 

--- a/receiver/awscloudwatchreceiver/metrics.go
+++ b/receiver/awscloudwatchreceiver/metrics.go
@@ -9,7 +9,6 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -52,11 +51,13 @@ type cloudWatchMetricsScraper struct {
 	client             metricsClient
 	stsClient          stsClient
 	// accountID is the resolved AWS account ID reported as cloud.account.id.
-	// It is empty when resolution failed and no account_id override was configured.
+	// It is empty until resolution succeeds.
 	accountID string
-	// accountIDOnce ensures the account ID is resolved at most once, lazily on the
-	// first scrape, so that start() performs no network calls.
-	accountIDOnce sync.Once
+	// accountIDResolved is set once the account ID has been resolved successfully. Until
+	// then resolution is retried on each scrape, so a transient STS failure on the first
+	// attempt does not permanently leave cloud.account.id unset. Resolution runs lazily on
+	// scrape (not in start()) so that start() performs no network calls.
+	accountIDResolved bool
 }
 
 type metricsClient interface {
@@ -121,25 +122,23 @@ func (s *cloudWatchMetricsScraper) start(ctx context.Context, host component.Hos
 
 // resolveAccountID resolves the AWS account ID of the active credentials via STS
 // GetCallerIdentity and stores it in s.accountID, to be reported as the cloud.account.id
-// resource attribute. If resolution fails (for example because STS is unavailable or not
-// permitted), it logs a warning and leaves s.accountID empty so that metric collection
-// proceeds without the attribute.
-//
-// It is invoked once, lazily, on the first scrape (via accountIDOnce) so that start()
-// performs no network calls.
+// resource attribute. It runs lazily on scrape (not in start(), which performs no network
+// calls) and retries on each scrape until it succeeds: a transient failure logs a warning
+// and leaves s.accountID empty for that cycle rather than latching the empty value, so
+// metrics are emitted without the attribute only until resolution succeeds.
 func (s *cloudWatchMetricsScraper) resolveAccountID(ctx context.Context) {
-	s.accountIDOnce.Do(func() {
-		if s.stsClient == nil {
-			return
-		}
-		out, err := s.stsClient.GetCallerIdentity(ctx, &sts.GetCallerIdentityInput{})
-		if err != nil {
-			s.settings.Logger.Warn("unable to resolve AWS account ID via STS GetCallerIdentity; "+
-				"metrics will be emitted without the cloud.account.id resource attribute.", zap.Error(err))
-			return
-		}
-		s.accountID = aws.ToString(out.Account)
-	})
+	if s.accountIDResolved || s.stsClient == nil {
+		return
+	}
+	out, err := s.stsClient.GetCallerIdentity(ctx, &sts.GetCallerIdentityInput{})
+	if err != nil {
+		s.settings.Logger.Warn("unable to resolve AWS account ID via STS GetCallerIdentity; "+
+			"will retry on the next scrape. Metrics are emitted without the cloud.account.id "+
+			"resource attribute until resolution succeeds.", zap.Error(err))
+		return
+	}
+	s.accountID = aws.ToString(out.Account)
+	s.accountIDResolved = true
 }
 
 func (s *cloudWatchMetricsScraper) scrape(ctx context.Context) (pmetric.Metrics, error) {

--- a/receiver/awscloudwatchreceiver/metrics.go
+++ b/receiver/awscloudwatchreceiver/metrics.go
@@ -265,9 +265,21 @@ func (s *cloudWatchMetricsScraper) discoverMetrics(ctx context.Context, owningAc
 		if err != nil {
 			return nil, err
 		}
+		dropped := 0
 		for i, met := range resp.Metrics {
-			account := owningAccount
-			if account == "" && i < len(resp.OwningAccounts) {
+			var account string
+			if singleAccount {
+				// Per-identifier discovery uses the requested account; same-account discovery
+				// leaves it empty so the receiver's own resolved account is used.
+				account = owningAccount
+			} else if i >= len(resp.OwningAccounts) || resp.OwningAccounts[i] == "" {
+				// Linked-account sweep where AWS did not return an aligned OwningAccounts entry:
+				// the metric cannot be attributed to a source account, so drop it rather than
+				// misattributing it to the monitoring account.
+				dropped++
+				continue
+			} else {
+				// Linked-account sweep: attribute the metric to its source account.
 				account = resp.OwningAccounts[i]
 			}
 			if perAccount[account] >= s.discovery.Limit {
@@ -284,6 +296,13 @@ func (s *cloudWatchMetricsScraper) discoverMetrics(ctx context.Context, owningAc
 				Stats:      s.discovery.Stats,
 				AccountID:  account,
 			})
+		}
+		if dropped > 0 {
+			s.settings.Logger.Warn("dropped discovered metrics that could not be attributed to a source "+
+				"account; ListMetrics OwningAccounts did not align 1:1 with the returned metrics",
+				zap.Int("dropped", dropped),
+				zap.Int("metrics", len(resp.Metrics)),
+				zap.Int("owning_accounts", len(resp.OwningAccounts)))
 		}
 		nextToken = resp.NextToken
 		if nextToken == nil {

--- a/receiver/awscloudwatchreceiver/metrics.go
+++ b/receiver/awscloudwatchreceiver/metrics.go
@@ -268,17 +268,18 @@ func (s *cloudWatchMetricsScraper) discoverMetrics(ctx context.Context, owningAc
 		dropped := 0
 		for i, met := range resp.Metrics {
 			var account string
-			if singleAccount {
+			switch {
+			case singleAccount:
 				// Per-identifier discovery uses the requested account; same-account discovery
 				// leaves it empty so the receiver's own resolved account is used.
 				account = owningAccount
-			} else if i >= len(resp.OwningAccounts) || resp.OwningAccounts[i] == "" {
+			case i >= len(resp.OwningAccounts) || resp.OwningAccounts[i] == "":
 				// Linked-account sweep where AWS did not return an aligned OwningAccounts entry:
 				// the metric cannot be attributed to a source account, so drop it rather than
 				// misattributing it to the monitoring account.
 				dropped++
 				continue
-			} else {
+			default:
 				// Linked-account sweep: attribute the metric to its source account.
 				account = resp.OwningAccounts[i]
 			}

--- a/receiver/awscloudwatchreceiver/metrics.go
+++ b/receiver/awscloudwatchreceiver/metrics.go
@@ -9,12 +9,14 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatch"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
@@ -48,11 +50,23 @@ type cloudWatchMetricsScraper struct {
 	metrics            []MetricQuery
 	discovery          *MetricsDiscoveryConfig
 	client             metricsClient
+	stsClient          stsClient
+	// accountID is the resolved AWS account ID reported as cloud.account.id.
+	// It is empty when resolution failed and no account_id override was configured.
+	accountID string
+	// accountIDOnce ensures the account ID is resolved at most once, lazily on the
+	// first scrape, so that start() performs no network calls.
+	accountIDOnce sync.Once
 }
 
 type metricsClient interface {
 	ListMetrics(ctx context.Context, params *cloudwatch.ListMetricsInput, optFns ...func(*cloudwatch.Options)) (*cloudwatch.ListMetricsOutput, error)
 	GetMetricData(ctx context.Context, params *cloudwatch.GetMetricDataInput, optFns ...func(*cloudwatch.Options)) (*cloudwatch.GetMetricDataOutput, error)
+}
+
+// stsClient resolves the AWS account ID of the active credentials via GetCallerIdentity.
+type stsClient interface {
+	GetCallerIdentity(ctx context.Context, params *sts.GetCallerIdentityInput, optFns ...func(*sts.Options)) (*sts.GetCallerIdentityOutput, error)
 }
 
 func newCloudWatchMetricsScraper(cfg *Config, settings receiver.Settings) *cloudWatchMetricsScraper {
@@ -96,11 +110,40 @@ func (s *cloudWatchMetricsScraper) start(ctx context.Context, host component.Hos
 		cfg.Credentials = creds
 	}
 	s.client = cloudwatch.NewFromConfig(cfg)
+	if s.stsClient == nil {
+		s.stsClient = sts.NewFromConfig(cfg)
+	}
 	return nil
+}
+
+// resolveAccountID resolves the AWS account ID of the active credentials via STS
+// GetCallerIdentity and stores it in s.accountID, to be reported as the cloud.account.id
+// resource attribute. If resolution fails (for example because STS is unavailable or not
+// permitted), it logs a warning and leaves s.accountID empty so that metric collection
+// proceeds without the attribute.
+//
+// It is invoked once, lazily, on the first scrape (via accountIDOnce) so that start()
+// performs no network calls.
+func (s *cloudWatchMetricsScraper) resolveAccountID(ctx context.Context) {
+	s.accountIDOnce.Do(func() {
+		if s.stsClient == nil {
+			return
+		}
+		out, err := s.stsClient.GetCallerIdentity(ctx, &sts.GetCallerIdentityInput{})
+		if err != nil {
+			s.settings.Logger.Warn("unable to resolve AWS account ID via STS GetCallerIdentity; "+
+				"metrics will be emitted without the cloud.account.id resource attribute.", zap.Error(err))
+			return
+		}
+		s.accountID = aws.ToString(out.Account)
+	})
 }
 
 func (s *cloudWatchMetricsScraper) scrape(ctx context.Context) (pmetric.Metrics, error) {
 	s.settings.Logger.Debug("scraping CloudWatch metrics", zap.String("region", s.cfg.Region))
+
+	// Resolve the account ID lazily on the first scrape so that start() makes no network calls.
+	s.resolveAccountID(ctx)
 
 	var metricsToScrape []MetricQuery
 	if s.discovery != nil {
@@ -313,11 +356,15 @@ func dimensionsFromMap(d map[string]string) []types.Dimension {
 }
 
 // setResourceAttributes sets the resource-level attributes that identify the AWS source.
-// Aligned with the CloudWatch Metric Streams OpenTelemetry 1.0.0 format: only cloud.provider
-// and cloud.region are set on the resource; namespace and dimensions go on data points.
+// Aligned with the CloudWatch Metric Streams OpenTelemetry 1.0.0 format: cloud.provider,
+// cloud.account.id, and cloud.region are set on the resource; namespace and dimensions go
+// on data points. cloud.account.id is omitted when the account ID could not be resolved.
 func (s *cloudWatchMetricsScraper) setResourceAttributes(resource pcommon.Resource) {
 	attrs := resource.Attributes()
 	attrs.PutStr(string(conventions.CloudProviderKey), conventions.CloudProviderAWS.Value.AsString())
+	if s.accountID != "" {
+		attrs.PutStr(string(conventions.CloudAccountIDKey), s.accountID)
+	}
 	attrs.PutStr(string(conventions.CloudRegionKey), s.cfg.Region)
 }
 

--- a/receiver/awscloudwatchreceiver/metrics.go
+++ b/receiver/awscloudwatchreceiver/metrics.go
@@ -110,6 +110,9 @@ func (s *cloudWatchMetricsScraper) start(ctx context.Context, host component.Hos
 		cfg.Credentials = creds
 	}
 	s.client = cloudwatch.NewFromConfig(cfg)
+	// Build the STS client from the same cfg AFTER the credentials override so that
+	// GetCallerIdentity resolves the effective (possibly assumed-role) account that the
+	// CloudWatch client also uses, rather than the base credentials' account.
 	if s.stsClient == nil {
 		s.stsClient = sts.NewFromConfig(cfg)
 	}

--- a/receiver/awscloudwatchreceiver/metrics.go
+++ b/receiver/awscloudwatchreceiver/metrics.go
@@ -203,8 +203,36 @@ func alignTimeToPeriod(t time.Time, periodSec int64) time.Time {
 	return time.Unix(aligned, 0).UTC()
 }
 
-// listMetrics discovers metrics via ListMetrics API, respecting discovery config (namespace, metric name, limit).
+// listMetrics discovers metrics via the ListMetrics API, respecting discovery config
+// (namespace, metric name, limit, and cross-account options).
+//
+// When account_identifiers is set, each source account is queried separately because
+// ListMetrics filters a single owning account at a time; the limit applies per account.
+// When include_linked_accounts is set without identifiers, a single monitoring-account
+// sweep discovers metrics across all linked accounts, again capped per account. Otherwise
+// the receiver's own account is discovered as before.
 func (s *cloudWatchMetricsScraper) listMetrics(ctx context.Context) ([]MetricQuery, error) {
+	if len(s.discovery.AccountIdentifiers) > 0 {
+		var out []MetricQuery
+		for _, account := range s.discovery.AccountIdentifiers {
+			qs, err := s.discoverMetrics(ctx, account)
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, qs...)
+		}
+		return out, nil
+	}
+	return s.discoverMetrics(ctx, "")
+}
+
+// discoverMetrics paginates ListMetrics for a single owning account (or, when
+// owningAccount is empty and include_linked_accounts is set, a sweep across all linked
+// accounts). The discovery limit is enforced per account. Each returned MetricQuery is
+// tagged with the account that owns it, or left empty for same-account discovery.
+func (s *cloudWatchMetricsScraper) discoverMetrics(ctx context.Context, owningAccount string) ([]MetricQuery, error) {
+	includeLinked := s.discovery.IncludeLinkedAccounts != nil && *s.discovery.IncludeLinkedAccounts
+
 	input := &cloudwatch.ListMetricsInput{}
 	if f := s.discovery.Filters.Get(); f != nil {
 		if f.Namespace != "" {
@@ -214,7 +242,19 @@ func (s *cloudWatchMetricsScraper) listMetrics(ctx context.Context) ([]MetricQue
 			input.MetricName = aws.String(f.MetricName)
 		}
 	}
+	if includeLinked {
+		input.IncludeLinkedAccounts = aws.Bool(true)
+	}
+	if owningAccount != "" {
+		input.OwningAccount = aws.String(owningAccount)
+	}
 
+	// singleAccount is true whenever every returned metric belongs to one account, so we
+	// can stop paginating once the limit is reached. The all-linked sweep must page fully
+	// because metrics for under-limit accounts may still appear on later pages.
+	singleAccount := owningAccount != "" || !includeLinked
+
+	perAccount := make(map[string]int)
 	var out []MetricQuery
 	var nextToken *string
 	for {
@@ -223,17 +263,25 @@ func (s *cloudWatchMetricsScraper) listMetrics(ctx context.Context) ([]MetricQue
 		if err != nil {
 			return nil, err
 		}
-		for _, met := range resp.Metrics {
-			if len(out) >= s.discovery.Limit {
-				return out, nil
+		for i, met := range resp.Metrics {
+			account := owningAccount
+			if account == "" && i < len(resp.OwningAccounts) {
+				account = resp.OwningAccounts[i]
 			}
-			q := MetricQuery{
+			if perAccount[account] >= s.discovery.Limit {
+				if singleAccount {
+					return out, nil
+				}
+				continue
+			}
+			perAccount[account]++
+			out = append(out, MetricQuery{
 				Namespace:  aws.ToString(met.Namespace),
 				MetricName: aws.ToString(met.MetricName),
 				Dimensions: dimensionsToMap(met.Dimensions),
 				Stats:      s.discovery.Stats,
-			}
-			out = append(out, q)
+				AccountID:  account,
+			})
 		}
 		nextToken = resp.NextToken
 		if nextToken == nil {
@@ -285,7 +333,7 @@ func (s *cloudWatchMetricsScraper) pollBatch(ctx context.Context, batch []Metric
 			stats = q.Stats
 		}
 		for si, stat := range stats {
-			queries = append(queries, types.MetricDataQuery{
+			mdq := types.MetricDataQuery{
 				Id: aws.String(fmt.Sprintf("q%d_%d", i, si)),
 				MetricStat: &types.MetricStat{
 					Metric: &types.Metric{
@@ -296,7 +344,12 @@ func (s *cloudWatchMetricsScraper) pollBatch(ctx context.Context, batch []Metric
 					Period: aws.Int32(int32(s.period.Seconds())),
 					Stat:   aws.String(stat),
 				},
-			})
+			}
+			// In a cross-account setup, fetch the metric from its owning source account.
+			if q.AccountID != "" {
+				mdq.AccountId = aws.String(q.AccountID)
+			}
+			queries = append(queries, mdq)
 		}
 	}
 

--- a/receiver/awscloudwatchreceiver/metrics_test.go
+++ b/receiver/awscloudwatchreceiver/metrics_test.go
@@ -703,6 +703,30 @@ func TestPollBatch_SetsAccountIDOnQueries(t *testing.T) {
 	mc.AssertExpectations(t)
 }
 
+func TestPollBatch_ForbiddenStatusProducesNoData(t *testing.T) {
+	ts := time.Unix(1_700_000_000, 0).UTC()
+	mc := &mockMetricsClient{}
+	// A Forbidden cross-account result carries no values; conversion must drop it
+	// (no resource metrics) rather than fabricate empty data.
+	mc.On("GetMetricData", mock.Anything, mock.Anything, mock.Anything).Return(
+		&cloudwatch.GetMetricDataOutput{
+			MetricDataResults: []types.MetricDataResult{
+				{Id: aws.String("q0_0"), StatusCode: types.StatusCodeForbidden},
+			},
+		}, nil,
+	)
+
+	cfg := &Config{Region: "us-east-1", Metrics: MetricsConfig{Period: 60 * time.Second}}
+	scr := testScraper(cfg)
+	scr.client = mc
+
+	batch := []MetricQuery{{Namespace: "AWS/EC2", MetricName: "CPUUtilization", Stats: []string{"Sum"}, AccountID: "222222222222"}}
+	md, err := scr.pollBatch(t.Context(), batch, ts.Add(-60*time.Second), ts)
+	require.NoError(t, err)
+	require.Equal(t, 0, md.ResourceMetrics().Len())
+	mc.AssertExpectations(t)
+}
+
 func TestPollBatch_Error(t *testing.T) {
 	ts := time.Unix(1_700_000_000, 0).UTC()
 	mc := &mockMetricsClient{}

--- a/receiver/awscloudwatchreceiver/metrics_test.go
+++ b/receiver/awscloudwatchreceiver/metrics_test.go
@@ -293,6 +293,36 @@ func TestConvertGetMetricDataToPdata_MultipleMetrics(t *testing.T) {
 	require.ElementsMatch(t, []string{"amazonaws.com/AWS/EC2/CPUUtilization", "amazonaws.com/AWS/EC2/NetworkIn"}, names)
 }
 
+func TestConvertGetMetricDataToPdata_GroupsByAccount(t *testing.T) {
+	// Receiver's own account; one query overrides it with a source account.
+	scr := testScraper(&Config{Region: "us-east-1"})
+	scr.accountID = "111111111111"
+
+	ts := time.Unix(1_700_000_000, 0).UTC()
+	results := []types.MetricDataResult{
+		{Id: aws.String("q0_1"), Values: []float64{1.0}, Timestamps: []time.Time{ts}},
+		{Id: aws.String("q1_1"), Values: []float64{2.0}, Timestamps: []time.Time{ts}},
+	}
+	batch := []MetricQuery{
+		{Namespace: "AWS/EC2", MetricName: "CPUUtilization"},                       // own account
+		{Namespace: "AWS/EC2", MetricName: "NetworkIn", AccountID: "222222222222"}, // source account
+	}
+
+	md := scr.convertGetMetricDataToPdata(results, batch, ts)
+	require.Equal(t, 2, md.ResourceMetrics().Len())
+
+	byAccount := map[string]string{} // account ID -> metric name
+	for i := 0; i < md.ResourceMetrics().Len(); i++ {
+		rm := md.ResourceMetrics().At(i)
+		acct, ok := rm.Resource().Attributes().Get("cloud.account.id")
+		require.True(t, ok)
+		require.Equal(t, 1, rm.ScopeMetrics().At(0).Metrics().Len())
+		byAccount[acct.Str()] = rm.ScopeMetrics().At(0).Metrics().At(0).Name()
+	}
+	require.Equal(t, "amazonaws.com/AWS/EC2/CPUUtilization", byAccount["111111111111"])
+	require.Equal(t, "amazonaws.com/AWS/EC2/NetworkIn", byAccount["222222222222"])
+}
+
 // --- gauge mode tests ---
 
 func TestConvertGetMetricDataToPdata_GaugeMode_SingleStat(t *testing.T) {

--- a/receiver/awscloudwatchreceiver/metrics_test.go
+++ b/receiver/awscloudwatchreceiver/metrics_test.go
@@ -879,7 +879,29 @@ func TestResolveAccountID_ResolvesOnlyOnce(t *testing.T) {
 	scr.resolveAccountID(t.Context())
 	scr.resolveAccountID(t.Context())
 	require.Equal(t, "210987654321", scr.accountID)
-	// GetCallerIdentity must be called at most once across repeated scrapes.
+	// Once resolved successfully, GetCallerIdentity is not called again on later scrapes.
+	stsMock.AssertExpectations(t)
+}
+
+func TestResolveAccountID_RetriesAfterTransientFailure(t *testing.T) {
+	cfg := &Config{Region: "us-east-1"}
+	scr := testScraper(cfg)
+	stsMock := &mockSTSClient{}
+	// First scrape's call fails transiently; the next succeeds.
+	stsMock.On("GetCallerIdentity", mock.Anything, mock.Anything, mock.Anything).Return(
+		(*sts.GetCallerIdentityOutput)(nil), errors.New("timeout"),
+	).Once()
+	stsMock.On("GetCallerIdentity", mock.Anything, mock.Anything, mock.Anything).Return(
+		&sts.GetCallerIdentityOutput{Account: aws.String("210987654321")}, nil,
+	).Once()
+	scr.stsClient = stsMock
+
+	scr.resolveAccountID(t.Context())
+	require.Empty(t, scr.accountID, "transient failure must not latch an empty account ID")
+	scr.resolveAccountID(t.Context())
+	require.Equal(t, "210987654321", scr.accountID, "resolution must be retried and succeed")
+	// A third scrape must not call again now that resolution has succeeded.
+	scr.resolveAccountID(t.Context())
 	stsMock.AssertExpectations(t)
 }
 

--- a/receiver/awscloudwatchreceiver/metrics_test.go
+++ b/receiver/awscloudwatchreceiver/metrics_test.go
@@ -533,6 +533,113 @@ func TestListMetrics_Error(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestListMetrics_PerAccountIdentifiers(t *testing.T) {
+	mc := &mockMetricsClient{}
+	// One ListMetrics call per requested account, each filtered by OwningAccount with
+	// IncludeLinkedAccounts set. The discovered MetricQuery is tagged with that account.
+	for _, account := range []string{"111111111111", "222222222222"} {
+		mc.On("ListMetrics", mock.Anything, mock.MatchedBy(func(p *cloudwatch.ListMetricsInput) bool {
+			return p.OwningAccount != nil && *p.OwningAccount == account &&
+				p.IncludeLinkedAccounts != nil && *p.IncludeLinkedAccounts
+		}), mock.Anything).Return(
+			&cloudwatch.ListMetricsOutput{
+				Metrics: []types.Metric{
+					{Namespace: aws.String("AWS/EC2"), MetricName: aws.String("CPUUtilization")},
+				},
+			}, nil,
+		).Once()
+	}
+
+	cfg := &Config{Region: "us-east-1", Metrics: MetricsConfig{
+		Discovery: &MetricsDiscoveryConfig{
+			Limit:                 100,
+			IncludeLinkedAccounts: aws.Bool(true),
+			AccountIdentifiers:    []string{"111111111111", "222222222222"},
+		},
+	}}
+	scr := testScraper(cfg)
+	scr.client = mc
+
+	out, err := scr.listMetrics(t.Context())
+	require.NoError(t, err)
+	require.Len(t, out, 2)
+	accounts := []string{out[0].AccountID, out[1].AccountID}
+	require.ElementsMatch(t, []string{"111111111111", "222222222222"}, accounts)
+	mc.AssertExpectations(t)
+}
+
+func TestListMetrics_LinkedAccountsSweep(t *testing.T) {
+	mc := &mockMetricsClient{}
+	// Monitoring-account sweep: IncludeLinkedAccounts true, no OwningAccount filter.
+	// OwningAccounts is a 1:1 mapping to Metrics and tags each discovered query.
+	mc.On("ListMetrics", mock.Anything, mock.MatchedBy(func(p *cloudwatch.ListMetricsInput) bool {
+		return p.OwningAccount == nil && p.IncludeLinkedAccounts != nil && *p.IncludeLinkedAccounts
+	}), mock.Anything).Return(
+		&cloudwatch.ListMetricsOutput{
+			Metrics: []types.Metric{
+				{Namespace: aws.String("AWS/EC2"), MetricName: aws.String("CPUUtilization")},
+				{Namespace: aws.String("AWS/EC2"), MetricName: aws.String("NetworkIn")},
+			},
+			OwningAccounts: []string{"111111111111", "222222222222"},
+		}, nil,
+	)
+
+	cfg := &Config{Region: "us-east-1", Metrics: MetricsConfig{
+		Discovery: &MetricsDiscoveryConfig{
+			Limit:                 100,
+			IncludeLinkedAccounts: aws.Bool(true),
+		},
+	}}
+	scr := testScraper(cfg)
+	scr.client = mc
+
+	out, err := scr.listMetrics(t.Context())
+	require.NoError(t, err)
+	require.Len(t, out, 2)
+	byMetric := map[string]string{}
+	for _, q := range out {
+		byMetric[q.MetricName] = q.AccountID
+	}
+	require.Equal(t, "111111111111", byMetric["CPUUtilization"])
+	require.Equal(t, "222222222222", byMetric["NetworkIn"])
+	mc.AssertExpectations(t)
+}
+
+func TestListMetrics_LimitIsPerAccountInSweep(t *testing.T) {
+	mc := &mockMetricsClient{}
+	// Two accounts, limit 1 each: one metric per account is kept, the rest dropped.
+	mc.On("ListMetrics", mock.Anything, mock.Anything, mock.Anything).Return(
+		&cloudwatch.ListMetricsOutput{
+			Metrics: []types.Metric{
+				{Namespace: aws.String("AWS/EC2"), MetricName: aws.String("M1")},
+				{Namespace: aws.String("AWS/EC2"), MetricName: aws.String("M2")},
+				{Namespace: aws.String("AWS/EC2"), MetricName: aws.String("M3")},
+			},
+			OwningAccounts: []string{"111111111111", "111111111111", "222222222222"},
+		}, nil,
+	)
+
+	cfg := &Config{Region: "us-east-1", Metrics: MetricsConfig{
+		Discovery: &MetricsDiscoveryConfig{
+			Limit:                 1,
+			IncludeLinkedAccounts: aws.Bool(true),
+		},
+	}}
+	scr := testScraper(cfg)
+	scr.client = mc
+
+	out, err := scr.listMetrics(t.Context())
+	require.NoError(t, err)
+	// One kept per account (M1 for 111…, M3 for 222…); M2 exceeds account 111's limit.
+	require.Len(t, out, 2)
+	perAccount := map[string]int{}
+	for _, q := range out {
+		perAccount[q.AccountID]++
+	}
+	require.Equal(t, 1, perAccount["111111111111"])
+	require.Equal(t, 1, perAccount["222222222222"])
+}
+
 // --- pollBatch tests ---
 
 func TestPollBatch_GeneratesFourSubQueries(t *testing.T) {
@@ -564,6 +671,35 @@ func TestPollBatch_GeneratesFourSubQueries(t *testing.T) {
 	dp := md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).Summary().DataPoints().At(0)
 	require.Equal(t, uint64(3), dp.Count())
 	require.InDelta(t, 20.0, dp.Sum(), 0.001)
+	mc.AssertExpectations(t)
+}
+
+func TestPollBatch_SetsAccountIDOnQueries(t *testing.T) {
+	ts := time.Unix(1_700_000_000, 0).UTC()
+	mc := &mockMetricsClient{}
+	mc.On("GetMetricData", mock.Anything, mock.MatchedBy(func(p *cloudwatch.GetMetricDataInput) bool {
+		// Every sub-query for a cross-account metric must carry its source AccountId.
+		for _, q := range p.MetricDataQueries {
+			if q.AccountId == nil || *q.AccountId != "222222222222" {
+				return false
+			}
+		}
+		return len(p.MetricDataQueries) > 0
+	}), mock.Anything).Return(
+		&cloudwatch.GetMetricDataOutput{
+			MetricDataResults: []types.MetricDataResult{
+				{Id: aws.String("q0_0"), Values: []float64{1.0}, Timestamps: []time.Time{ts}},
+			},
+		}, nil,
+	)
+
+	cfg := &Config{Region: "us-east-1", Metrics: MetricsConfig{Period: 60 * time.Second}}
+	scr := testScraper(cfg)
+	scr.client = mc
+
+	batch := []MetricQuery{{Namespace: "AWS/EC2", MetricName: "CPUUtilization", Stats: []string{"Sum"}, AccountID: "222222222222"}}
+	_, err := scr.pollBatch(t.Context(), batch, ts.Add(-60*time.Second), ts)
+	require.NoError(t, err)
 	mc.AssertExpectations(t)
 }
 

--- a/receiver/awscloudwatchreceiver/metrics_test.go
+++ b/receiver/awscloudwatchreceiver/metrics_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatch"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
@@ -35,6 +36,17 @@ func (m *mockMetricsClient) ListMetrics(ctx context.Context, params *cloudwatch.
 func (m *mockMetricsClient) GetMetricData(ctx context.Context, params *cloudwatch.GetMetricDataInput, optFns ...func(*cloudwatch.Options)) (*cloudwatch.GetMetricDataOutput, error) {
 	args := m.Called(ctx, params, optFns)
 	return args.Get(0).(*cloudwatch.GetMetricDataOutput), args.Error(1)
+}
+
+// mockSTSClient implements stsClient for testing.
+type mockSTSClient struct {
+	mock.Mock
+}
+
+func (m *mockSTSClient) GetCallerIdentity(ctx context.Context, params *sts.GetCallerIdentityInput, optFns ...func(*sts.Options)) (*sts.GetCallerIdentityOutput, error) {
+	args := m.Called(ctx, params, optFns)
+	out, _ := args.Get(0).(*sts.GetCallerIdentityOutput)
+	return out, args.Error(1)
 }
 
 func testScraper(cfg *Config) *cloudWatchMetricsScraper {
@@ -647,4 +659,83 @@ func TestScrape_DiscoveryError(t *testing.T) {
 
 	_, err := scr.scrape(t.Context())
 	require.ErrorContains(t, err, "list metrics")
+}
+
+// --- account ID tests ---
+
+func TestResolveAccountID_ViaSTS(t *testing.T) {
+	cfg := &Config{Region: "us-east-1"}
+	scr := testScraper(cfg)
+	stsMock := &mockSTSClient{}
+	stsMock.On("GetCallerIdentity", mock.Anything, mock.Anything, mock.Anything).Return(
+		&sts.GetCallerIdentityOutput{Account: aws.String("210987654321")}, nil,
+	)
+	scr.stsClient = stsMock
+
+	scr.resolveAccountID(t.Context())
+	require.Equal(t, "210987654321", scr.accountID)
+	stsMock.AssertExpectations(t)
+}
+
+func TestResolveAccountID_ResolvesOnlyOnce(t *testing.T) {
+	cfg := &Config{Region: "us-east-1"}
+	scr := testScraper(cfg)
+	stsMock := &mockSTSClient{}
+	stsMock.On("GetCallerIdentity", mock.Anything, mock.Anything, mock.Anything).Return(
+		&sts.GetCallerIdentityOutput{Account: aws.String("210987654321")}, nil,
+	).Once()
+	scr.stsClient = stsMock
+
+	scr.resolveAccountID(t.Context())
+	scr.resolveAccountID(t.Context())
+	require.Equal(t, "210987654321", scr.accountID)
+	// GetCallerIdentity must be called at most once across repeated scrapes.
+	stsMock.AssertExpectations(t)
+}
+
+func TestResolveAccountID_STSErrorDegradesGracefully(t *testing.T) {
+	cfg := &Config{Region: "us-east-1"}
+	scr := testScraper(cfg)
+	stsMock := &mockSTSClient{}
+	stsMock.On("GetCallerIdentity", mock.Anything, mock.Anything, mock.Anything).Return(
+		(*sts.GetCallerIdentityOutput)(nil), errors.New("access denied"),
+	)
+	scr.stsClient = stsMock
+
+	scr.resolveAccountID(t.Context())
+	require.Empty(t, scr.accountID)
+}
+
+func TestSetResourceAttributes_AccountID(t *testing.T) {
+	t.Run("present when resolved", func(t *testing.T) {
+		scr := testScraper(&Config{Region: "us-east-1"})
+		scr.accountID = "123456789012"
+
+		ts := time.Unix(1_700_000_000, 0).UTC()
+		results := []types.MetricDataResult{
+			{Id: aws.String("q0_1"), Values: []float64{1.0}, Timestamps: []time.Time{ts}},
+		}
+		batch := []MetricQuery{{Namespace: "AWS/EC2", MetricName: "CPUUtilization"}}
+
+		md := scr.convertGetMetricDataToPdata(results, batch, ts)
+		attrs := md.ResourceMetrics().At(0).Resource().Attributes()
+		v, ok := attrs.Get("cloud.account.id")
+		require.True(t, ok)
+		require.Equal(t, "123456789012", v.Str())
+	})
+
+	t.Run("omitted when unresolved", func(t *testing.T) {
+		scr := testScraper(&Config{Region: "us-east-1"})
+
+		ts := time.Unix(1_700_000_000, 0).UTC()
+		results := []types.MetricDataResult{
+			{Id: aws.String("q0_1"), Values: []float64{1.0}, Timestamps: []time.Time{ts}},
+		}
+		batch := []MetricQuery{{Namespace: "AWS/EC2", MetricName: "CPUUtilization"}}
+
+		md := scr.convertGetMetricDataToPdata(results, batch, ts)
+		attrs := md.ResourceMetrics().At(0).Resource().Attributes()
+		_, ok := attrs.Get("cloud.account.id")
+		require.False(t, ok)
+	})
 }

--- a/receiver/awscloudwatchreceiver/metrics_test.go
+++ b/receiver/awscloudwatchreceiver/metrics_test.go
@@ -640,6 +640,37 @@ func TestListMetrics_LimitIsPerAccountInSweep(t *testing.T) {
 	require.Equal(t, 1, perAccount["222222222222"])
 }
 
+func TestListMetrics_SweepDropsUnattributableMetrics(t *testing.T) {
+	mc := &mockMetricsClient{}
+	// Contract violation: OwningAccounts is shorter than Metrics. The unmappable metric
+	// must be dropped, not misattributed to the receiver's own account.
+	mc.On("ListMetrics", mock.Anything, mock.Anything, mock.Anything).Return(
+		&cloudwatch.ListMetricsOutput{
+			Metrics: []types.Metric{
+				{Namespace: aws.String("AWS/EC2"), MetricName: aws.String("M1")},
+				{Namespace: aws.String("AWS/EC2"), MetricName: aws.String("M2")},
+			},
+			OwningAccounts: []string{"111111111111"}, // missing entry for M2
+		}, nil,
+	)
+
+	cfg := &Config{Region: "us-east-1", Metrics: MetricsConfig{
+		Discovery: &MetricsDiscoveryConfig{
+			Limit:                 100,
+			IncludeLinkedAccounts: aws.Bool(true),
+		},
+	}}
+	scr := testScraper(cfg)
+	scr.accountID = "999999999999" // the receiver's own account; must NOT leak onto M2
+	scr.client = mc
+
+	out, err := scr.listMetrics(t.Context())
+	require.NoError(t, err)
+	require.Len(t, out, 1)
+	require.Equal(t, "M1", out[0].MetricName)
+	require.Equal(t, "111111111111", out[0].AccountID)
+}
+
 // --- pollBatch tests ---
 
 func TestPollBatch_GeneratesFourSubQueries(t *testing.T) {


### PR DESCRIPTION
## Summary

Adds AWS account attribution and cross-account monitoring support to the **metrics** path of the awscloudwatch receiver. Today the account is implicit in the credentials and no `cloud.account.id` is reported; CloudWatch's `GetMetricData`/`ListMetrics` responses don't carry it.

Built incrementally as three reviewable commits:

1. **Report `cloud.account.id` on collected metrics.** Resolve the AWS account ID once (lazily, on the first scrape, so `start()` makes no network calls) via STS `GetCallerIdentity`, and set it as the `cloud.account.id` resource attribute. If STS fails, a warning is logged and metrics are emitted without the attribute. This aligns the polling receiver with the CloudWatch Metric Streams OpenTelemetry 1.0.0 resource format already produced by `awsfirehosereceiver` (`cloud.provider`, `cloud.account.id`, `cloud.region`).

2. **Group `ResourceMetrics` by account ID.** `convertGetMetricDataToPdata` now emits one resource per account rather than one per batch, and `setResourceAttributes` takes the account explicitly. No observable change in the single-account case — structural prerequisite for cross-account.

3. **Cross-account metric collection.** A monitoring account can collect from linked source accounts:
   - Discovery gains `include_linked_accounts` and `account_identifiers`. Because `ListMetrics` filters one owning account at a time, each identifier is queried separately, so the discovery `limit` applies **per account**; an all-linked sweep (no identifiers) reads the response's `OwningAccounts`.
   - Explicit queries gain `account_id`, passed as the per-query `GetMetricData` `AccountId`.
   - Metrics are tagged with their owning account and grouped under the correct `cloud.account.id`. Validation rejects `account_identifiers` without `include_linked_accounts: true`. Default behavior (own account only) is unchanged.

The cross-account config vocabulary (`account_identifiers`, `include_linked_accounts`) mirrors the existing logs autodiscovery options for consistency.

## Testing

- Unit tests cover account-ID resolution (STS success / failure / once-only), per-account resource grouping, per-account discovery, the linked-accounts sweep with per-account limit, per-query `AccountId` wiring, and config validation.
- `go build`, `go vet`, `gofmt`, and the full package test suite pass.

## Notes

- The logs side does not currently validate the `account_identifiers` / `include_linked_accounts` pairing; the metrics validation here is intentionally stricter. Happy to align the logs side in a follow-up.
