### PR TITLE
github-actions: sync with force

### DIFF
--- a/.github/workflows/elastic-sync-fork.yml
+++ b/.github/workflows/elastic-sync-fork.yml
@@ -18,7 +18,7 @@ jobs:
         id: fetch-token
 
       - name: Synchronize fork
-        run: gh repo sync $REPOSITORY -b main
+        run: gh repo sync $REPOSITORY -b main --force
         env:
           GITHUB_TOKEN: ${{ steps.fetch-token.outputs.token }}
           REPOSITORY: ${{ github.repository }}


### PR DESCRIPTION
can't sync because there are diverging changes; use `--force` to overwrite the destination branch
