### PR TITLE
[receiver/awscloudwatch] Add recently_active metric discovery option

### DIFF
--- a/.chloggen/awscloudwatchreceiver-metrics-recently-active.yaml
+++ b/.chloggen/awscloudwatchreceiver-metrics-recently-active.yaml
@@ -4,7 +4,7 @@
 change_type: enhancement
 
 # The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
-component: awscloudwatchreceiver
+component: receiver/awscloudwatch
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: Add `metrics.discovery.recently_active` to restrict metric discovery to metrics active in the last three hours.

--- a/.chloggen/awscloudwatchreceiver-metrics-recently-active.yaml
+++ b/.chloggen/awscloudwatchreceiver-metrics-recently-active.yaml
@@ -1,0 +1,31 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: awscloudwatchreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add `metrics.discovery.recently_active` to restrict metric discovery to metrics active in the last three hours.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [49267]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  When `recently_active` is true, the receiver passes `RecentlyActive=PT3H` to `ListMetrics` so discovery
+  only returns metrics that published data in the past three hours instead of the default two-week window.
+  In accounts with high resource churn this can reduce the number of discovered metrics, and therefore
+  GetMetricData cost, by an order of magnitude.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/awscloudwatchreceiver/README.md
+++ b/receiver/awscloudwatchreceiver/README.md
@@ -100,6 +100,7 @@ Instead of listing metrics manually, the receiver can call [ListMetrics](https:/
 | `filters.metric_name`  | String          | —       | Restrict discovery to metrics with this name. |
 | `limit`                | Integer         | 100     | Maximum number of metrics to discover and scrape, applied **per account** (in a cross-account setup, each source account may contribute up to `limit` metrics). |
 | `stats`                | List of strings | —       | Statistics to fetch for every discovered metric. Same values as in `queries`. |
+| `recently_active`      | Boolean         | false   | When `true`, only discover metrics that published data in the **last three hours** (the `ListMetrics` `RecentlyActive=PT3H` filter) instead of the default two-week window. In accounts with high resource churn (e.g. autoscaling) this can reduce the number of discovered metrics — and therefore GetMetricData cost — by an order of magnitude, by excluding metrics from terminated resources. `PT3H` is the only window AWS supports for this filter. |
 | `include_linked_accounts` | Boolean      | false   | When running in a monitoring account, discover metrics from linked source accounts. See [Cross-account monitoring](#cross-account-monitoring). |
 | `account_identifiers`  | List of strings | —       | Restrict cross-account discovery to specific source account IDs (each a 12-digit account ID). Requires `include_linked_accounts: true`. When omitted (with `include_linked_accounts: true`), metrics from all linked accounts are discovered. |
 

--- a/receiver/awscloudwatchreceiver/config.go
+++ b/receiver/awscloudwatchreceiver/config.go
@@ -69,6 +69,13 @@ type MetricsDiscoveryConfig struct {
 	// Stats selects which CloudWatch statistics to fetch for all discovered metrics.
 	// Same semantics as MetricQuery.Stats.
 	Stats []string `mapstructure:"stats"`
+	// RecentlyActive, when true, restricts discovery to metrics that have published data
+	// in the past three hours (the ListMetrics RecentlyActive=PT3H filter). By default
+	// ListMetrics returns every metric that reported data in the past two weeks, which
+	// includes metrics from terminated resources. Enabling this dramatically reduces the
+	// number of discovered metrics (and therefore GetMetricData cost) in accounts with
+	// high resource churn. PT3H is the only window AWS supports for this filter.
+	RecentlyActive bool `mapstructure:"recently_active"`
 	// IncludeLinkedAccounts, when true and run from a monitoring account, discovers
 	// metrics from linked source accounts in addition to (or filtered by) AccountIdentifiers.
 	IncludeLinkedAccounts *bool `mapstructure:"include_linked_accounts"`

--- a/receiver/awscloudwatchreceiver/config.schema.yaml
+++ b/receiver/awscloudwatchreceiver/config.schema.yaml
@@ -101,14 +101,14 @@ $defs:
       limit:
         description: Limit is the maximum number of metrics to discover and scrape per account (default 100). In a cross-account setup it applies independently to each source account.
         type: integer
+      recently_active:
+        description: RecentlyActive, when true, restricts discovery to metrics that have published data in the past three hours (the ListMetrics RecentlyActive=PT3H filter). By default ListMetrics returns every metric that reported data in the past two weeks, which includes metrics from terminated resources. Enabling this dramatically reduces the number of discovered metrics (and therefore GetMetricData cost) in accounts with high resource churn. PT3H is the only window AWS supports for this filter.
+        type: boolean
       stats:
         description: Stats selects which CloudWatch statistics to fetch for all discovered metrics. Same semantics as MetricQuery.Stats.
         type: array
         items:
           type: string
-      recently_active:
-        description: RecentlyActive, when true, restricts discovery to metrics that have published data in the past three hours (the ListMetrics RecentlyActive=PT3H filter). By default ListMetrics returns every metric that reported data in the past two weeks, which includes metrics from terminated resources. PT3H is the only window AWS supports for this filter.
-        type: boolean
   metrics_discovery_filters:
     description: MetricsDiscoveryFilters optionally narrows which metrics are discovered. When absent, all metrics in all namespaces are discovered.
     type: object

--- a/receiver/awscloudwatchreceiver/config.schema.yaml
+++ b/receiver/awscloudwatchreceiver/config.schema.yaml
@@ -106,6 +106,9 @@ $defs:
         type: array
         items:
           type: string
+      recently_active:
+        description: RecentlyActive, when true, restricts discovery to metrics that have published data in the past three hours (the ListMetrics RecentlyActive=PT3H filter). By default ListMetrics returns every metric that reported data in the past two weeks, which includes metrics from terminated resources. PT3H is the only window AWS supports for this filter.
+        type: boolean
   metrics_discovery_filters:
     description: MetricsDiscoveryFilters optionally narrows which metrics are discovered. When absent, all metrics in all namespaces are discovered.
     type: object

--- a/receiver/awscloudwatchreceiver/config_test.go
+++ b/receiver/awscloudwatchreceiver/config_test.go
@@ -368,9 +368,10 @@ func TestLoadMetricsConfig(t *testing.T) {
 					Period:           300 * time.Second,
 					Delay:            defaultMetricsDelay,
 					Discovery: &MetricsDiscoveryConfig{
-						Filters: configoptional.Some(MetricsDiscoveryFilters{Namespace: "AWS/EC2"}),
-						Limit:   100,
-						Stats:   []string{"Sum", "Average"},
+						Filters:        configoptional.Some(MetricsDiscoveryFilters{Namespace: "AWS/EC2"}),
+						Limit:          100,
+						Stats:          []string{"Sum", "Average"},
+						RecentlyActive: true,
 					},
 				},
 			},

--- a/receiver/awscloudwatchreceiver/metrics.go
+++ b/receiver/awscloudwatchreceiver/metrics.go
@@ -250,6 +250,11 @@ func (s *cloudWatchMetricsScraper) discoverMetrics(ctx context.Context, owningAc
 	if owningAccount != "" {
 		input.OwningAccount = aws.String(owningAccount)
 	}
+	if s.discovery.RecentlyActive {
+		// Restrict discovery to metrics active in the last three hours. PT3H is the only
+		// value AWS accepts for this filter.
+		input.RecentlyActive = types.RecentlyActivePt3h
+	}
 
 	// singleAccount is true whenever every returned metric belongs to one account, so we
 	// can stop paginating once the limit is reached. The all-linked sweep must page fully

--- a/receiver/awscloudwatchreceiver/metrics_test.go
+++ b/receiver/awscloudwatchreceiver/metrics_test.go
@@ -461,6 +461,58 @@ func TestListMetrics_SinglePage(t *testing.T) {
 	mc.AssertExpectations(t)
 }
 
+func TestListMetrics_RecentlyActive(t *testing.T) {
+	mc := &mockMetricsClient{}
+	// When recently_active is enabled, ListMetrics must be called with RecentlyActive=PT3H.
+	mc.On("ListMetrics", mock.Anything, mock.MatchedBy(func(p *cloudwatch.ListMetricsInput) bool {
+		return p.RecentlyActive == types.RecentlyActivePt3h
+	}), mock.Anything).Return(
+		&cloudwatch.ListMetricsOutput{
+			Metrics: []types.Metric{
+				{Namespace: aws.String("AWS/EC2"), MetricName: aws.String("CPUUtilization")},
+			},
+			NextToken: nil,
+		}, nil,
+	)
+
+	cfg := &Config{Region: "us-east-1", Metrics: MetricsConfig{
+		Discovery: &MetricsDiscoveryConfig{Limit: 10, RecentlyActive: true},
+	}}
+	scr := testScraper(cfg)
+	scr.client = mc
+
+	out, err := scr.listMetrics(t.Context())
+	require.NoError(t, err)
+	require.Len(t, out, 1)
+	mc.AssertExpectations(t)
+}
+
+func TestListMetrics_RecentlyActiveUnsetByDefault(t *testing.T) {
+	mc := &mockMetricsClient{}
+	// Without recently_active, RecentlyActive must be left at its zero value so AWS
+	// applies the default two-week discovery window.
+	mc.On("ListMetrics", mock.Anything, mock.MatchedBy(func(p *cloudwatch.ListMetricsInput) bool {
+		return p.RecentlyActive == ""
+	}), mock.Anything).Return(
+		&cloudwatch.ListMetricsOutput{
+			Metrics: []types.Metric{
+				{Namespace: aws.String("AWS/EC2"), MetricName: aws.String("CPUUtilization")},
+			},
+			NextToken: nil,
+		}, nil,
+	)
+
+	cfg := &Config{Region: "us-east-1", Metrics: MetricsConfig{
+		Discovery: &MetricsDiscoveryConfig{Limit: 10},
+	}}
+	scr := testScraper(cfg)
+	scr.client = mc
+
+	_, err := scr.listMetrics(t.Context())
+	require.NoError(t, err)
+	mc.AssertExpectations(t)
+}
+
 func TestListMetrics_Paginated(t *testing.T) {
 	token := "next-page"
 	mc := &mockMetricsClient{}

--- a/receiver/awscloudwatchreceiver/testdata/config.yaml
+++ b/receiver/awscloudwatchreceiver/testdata/config.yaml
@@ -93,6 +93,7 @@ awscloudwatch/metrics-discovery-gauge:
         namespace: AWS/EC2
       limit: 100
       stats: [Sum, Average]
+      recently_active: true
 
 awscloudwatch/metrics-discovery-no-namespace:
   region: us-west-2


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Add `metrics.discovery.recently_active` config option. When true, the receiver passes `RecentlyActive=PT3H` to ListMetrics so discovery only returns metrics that published data in the past three hours instead of the default two-week window. In accounts with high resource churn this can reduce the number of discovered metrics, and therefore GetMetricData cost, by an order of magnitude.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #49267

<!--Describe what testing was performed and which tests were added.-->
#### Testing

Unit tests added that verify the default behaviour and that setting the config includes the param in the `ListMetrics` request.

<!--Describe the documentation added.-->
#### Documentation

Updated README with details of new option

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
